### PR TITLE
Upkeep: version bumps + CI uplift

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -56,5 +56,5 @@ jobs:
         uses: canonical/charm-logdump-action@main
         if: failure()
         with:
-          app: dashboard-k8s
-          model: testing
+          app: kubernetes-dashboard
+          model: dashboard

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,22 @@
-name: Run-Tests
-on: [pull_request, push]
+name: Tests
+on:
+  pull_request: {}
 
 jobs:
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -12,6 +27,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -22,6 +38,7 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
+
   integration-test-microk8s:
     name: Integration tests (microk8s)
     runs-on: ubuntu-latest
@@ -33,4 +50,11 @@ jobs:
         with:
           provider: microk8s
       - name: Run integration tests
-        run: tox -e integration
+        # set a predictable model name so it can be consumed by charm-logdump-action
+        run: tox -e integration -- --model testing
+      - name: Dump logs
+        uses: canonical/charm-logdump-action@main
+        if: failure()
+        with:
+          app: dashboard-k8s
+          model: testing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,8 +59,8 @@ jobs:
         uses: canonical/charm-logdump-action@main
         if: failure()
         with:
-          app: dashboard-k8s
-          model: testing
+          app: kubernetes-dashboard
+          model: dashboard
 
   release-to-charmhub:
     name: Release to CharmHub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,86 @@
+name: Release to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run tests
+        run: tox -e unit
+
+  integration-test:
+    name: Integration tests (microk8s)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+      - name: Run integration tests
+        # set a predictable model name so it can be consumed by charm-logdump-action
+        run: tox -e integration -- --model testing
+      - name: Dump logs
+        uses: canonical/charm-logdump-action@main
+        if: failure()
+        with:
+          app: dashboard-k8s
+          model: testing
+
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs:
+      - lib-check
+      - lint
+      - unit-test
+      - integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@1.0.3
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@1.0.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ at: https://kubernetes-dashboard-0.dashboard.svc.cluster.local.
 The charm requires the use of two OCI images, one for the dashboard, and one for the metrics
 scaper.
 
-- The dashboard image is [kubernetesui/dashboard:v2.4.0](https://hub.docker.com/r/kubernetesui/dashboard)
+- The dashboard image is [kubernetesui/dashboard:v2.6.0](https://hub.docker.com/r/kubernetesui/dashboard)
 - The metrics scraper image is
-  [kubernetesui/metrics-scraper:v1.0.7](https://hub.docker.com/r/kubernetesui/metrics-scraper)
+  [kubernetesui/metrics-scraper:v1.0.8](https://hub.docker.com/r/kubernetesui/metrics-scraper)

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,5 +11,11 @@ bases:
         channel: "20.04"
 parts:
   charm:
+    charm-python-packages: [setuptools, pip]
     build-packages:
       - git
+      # required for installing cffi:
+      - libffi-dev
+      # required for installing cryptography (cargo also contains rust):
+      - cargo
+      - libssl-dev

--- a/lib/charms/observability_libs/v0/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_service_patch.py
@@ -12,7 +12,7 @@ When modifying the default set of resources managed by Juju, one must consider t
 charm. In this case, any modifications to the default service (created during deployment), will
 be overwritten during a charm upgrade.
 
-When intialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
+When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are
 correct throughout the charm's life.
 
@@ -22,6 +22,8 @@ a port for the service, where each tuple contains:
 - a name for the port
 - port for the service to listen on
 - optionally: a targetPort for the service (the port in the container!)
+- optionally: a nodePort for the service (for NodePort or LoadBalancer services only!)
+- optionally: a name of the service (in case service name needs to be patched as well)
 
 ## Getting Started
 
@@ -39,6 +41,7 @@ EOF
 
 Then, to initialise the library:
 
+For ClusterIP services:
 ```python
 # ...
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
@@ -47,6 +50,20 @@ class SomeCharm(CharmBase):
   def __init__(self, *args):
     # ...
     self.service_patcher = KubernetesServicePatch(self, [(f"{self.app.name}", 8080)])
+    # ...
+```
+
+For LoadBalancer/NodePort services:
+```python
+# ...
+from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.service_patcher = KubernetesServicePatch(
+        self, [(f"{self.app.name}", 443, 443, 30666)], "LoadBalancer"
+    )
     # ...
 ```
 
@@ -66,7 +83,7 @@ def setUp(self, *unused):
 
 import logging
 from types import MethodType
-from typing import Sequence, Tuple, Union
+from typing import Literal, Sequence, Tuple, Union
 
 from lightkube import ApiError, Client
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
@@ -86,24 +103,51 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 6
 
-PortDefinition = Union[Tuple[str, int], Tuple[str, int, int]]
+PortDefinition = Union[Tuple[str, int], Tuple[str, int, int], Tuple[str, int, int, int]]
+ServiceType = Literal["ClusterIP", "LoadBalancer"]
 
 
 class KubernetesServicePatch(Object):
     """A utility for patching the Kubernetes service set up by Juju."""
 
-    def __init__(self, charm: CharmBase, ports: Sequence[PortDefinition]):
+    def __init__(
+        self,
+        charm: CharmBase,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ):
         """Constructor for KubernetesServicePatch.
 
         Args:
             charm: the charm that is instantiating the library.
-            ports: a list of tuples (name, port, targetPort) for every service port.
+            ports: a list of tuples (name, port, targetPort, nodePort) for every service port.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
         """
         super().__init__(charm, "kubernetes-service-patch")
         self.charm = charm
-        self.service = self._service_object(ports)
+        self.service_name = service_name if service_name else self._app
+        self.service = self._service_object(
+            ports,
+            service_name,
+            service_type,
+            additional_labels,
+            additional_selectors,
+            additional_annotations,
+        )
 
         # Make mypy type checking happy that self._patch is a method
         assert isinstance(self._patch, MethodType)
@@ -111,30 +155,64 @@ class KubernetesServicePatch(Object):
         self.framework.observe(charm.on.install, self._patch)
         self.framework.observe(charm.on.upgrade_charm, self._patch)
 
-    def _service_object(self, ports: Sequence[PortDefinition]) -> Service:
-        """Creates a valid Service representation for Alertmanager.
+    def _service_object(
+        self,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ) -> Service:
+        """Creates a valid Service representation.
 
         Args:
-            ports: a list of tuples of the form (name, port) or (name, port, targetPort) for every
-                service port. If the 'targetPort' is omitted, it is assumed to be equal to 'port'.
+            ports: a list of tuples of the form (name, port) or (name, port, targetPort)
+                or (name, port, targetPort, nodePort) for every service port. If the 'targetPort'
+                is omitted, it is assumed to be equal to 'port', with the exception of NodePort
+                and LoadBalancer services, where all port numbers have to be specified.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
 
         Returns:
             Service: A valid representation of a Kubernetes Service with the correct ports.
         """
+        if not service_name:
+            service_name = self._app
+        labels = {"app.kubernetes.io/name": self._app}
+        if additional_labels:
+            labels.update(additional_labels)
+        selector = {"app.kubernetes.io/name": self._app}
+        if additional_selectors:
+            selector.update(additional_selectors)
         return Service(
             apiVersion="v1",
             kind="Service",
             metadata=ObjectMeta(
                 namespace=self._namespace,
-                name=self._app,
-                labels={"app.kubernetes.io/name": self._app},
+                name=service_name,
+                labels=labels,
+                annotations=additional_annotations,  # type: ignore[arg-type]
             ),
             spec=ServiceSpec(
-                selector={"app.kubernetes.io/name": self._app},
+                selector=selector,
                 ports=[
-                    ServicePort(name=p[0], port=p[1], targetPort=p[2] if len(p) > 2 else p[1])  # type: ignore
+                    ServicePort(
+                        name=p[0],
+                        port=p[1],
+                        targetPort=p[2] if len(p) > 2 else p[1],  # type: ignore[misc]
+                        nodePort=p[3] if len(p) > 3 else None,  # type: ignore[arg-type, misc]
+                    )
                     for p in ports
                 ],
+                type=service_type,
             ),
         )
 
@@ -149,7 +227,9 @@ class KubernetesServicePatch(Object):
 
         client = Client()
         try:
-            client.patch(Service, self._app, self.service, patch_type=PatchType.MERGE)
+            if self.service_name != self._app:
+                self._delete_and_create_service(client)
+            client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
         except ApiError as e:
             if e.status.code == 403:
                 logger.error("Kubernetes service patch failed: `juju trust` this application.")
@@ -157,6 +237,13 @@ class KubernetesServicePatch(Object):
                 logger.error("Kubernetes service patch failed: %s", str(e))
         else:
             logger.info("Kubernetes service '%s' patched successfully", self._app)
+
+    def _delete_and_create_service(self, client: Client):
+        service = client.get(Service, self._app, namespace=self._namespace)
+        service.metadata.name = self.service_name  # type: ignore[attr-defined]
+        service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
+        client.delete(Service, self._app, namespace=self._namespace)
+        client.create(service)
 
     def is_patched(self) -> bool:
         """Reports if the service patch has been applied.
@@ -166,11 +253,11 @@ class KubernetesServicePatch(Object):
         """
         client = Client()
         # Get the relevant service from the cluster
-        service = client.get(Service, name=self._app, namespace=self._namespace)
+        service = client.get(Service, name=self.service_name, namespace=self._namespace)
         # Construct a list of expected ports, should the patch be applied
         expected_ports = [(p.port, p.targetPort) for p in self.service.spec.ports]
         # Construct a list in the same manner, using the fetched service
-        fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]
+        fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]  # type: ignore[attr-defined]  # noqa: E501
         return expected_ports == fetched_ports
 
     @property

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,8 +24,8 @@ resources:
   dashboard-image:
     type: oci-image
     description: OCI image for kubernetesui/dashboard
-    upstream-source: kubernetesui/dashboard:v2.4.0
+    upstream-source: kubernetesui/dashboard:v2.6.0
   scraper-image:
     type: oci-image
     description: OCI image for kubernetesui/metrics-scraper
-    upstream-source: kubernetesui/metrics-scraper:v1.0.7
+    upstream-source: kubernetesui/metrics-scraper:v1.0.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/canonical/operator/#egg=ops
+ops >= 1.5.0
 cryptography
-lightkube<=0.8.1
+lightkube
 lightkube-models
 jinja2<3.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,14 +18,9 @@ from cryptography import x509
 from cryptography.x509.base import Certificate
 from lightkube import Client, codecs
 from lightkube.core.exceptions import ApiError
-from lightkube.models.core_v1 import (
-    EmptyDirVolumeSource,
-    SecretVolumeSource,
-    Volume,
-    VolumeMount,
-)
+from lightkube.models.core_v1 import EmptyDirVolumeSource, Volume, VolumeMount
 from lightkube.resources.apps_v1 import StatefulSet
-from lightkube.resources.core_v1 import Service, ServiceAccount
+from lightkube.resources.core_v1 import Service
 from ops.charm import CharmBase, WorkloadEvent
 from ops.framework import StoredState
 from ops.main import main
@@ -211,14 +206,7 @@ class KubernetesDashboardCharm(CharmBase):
     @property
     def _dashboard_volumes(self) -> List[Volume]:
         """Returns the additional volumes required by the Dashboard."""
-        client = Client()
-        # Get the service account details so we can reference it's token
-        sa = client.get(ServiceAccount, name="kubernetes-dashboard", namespace=self._namespace)
         return [
-            Volume(
-                name="kubernetes-dashboard-service-account",
-                secret=SecretVolumeSource(secretName=sa.secrets[0].name),
-            ),
             Volume(name="tmp-volume-metrics", emptyDir=EmptyDirVolumeSource(medium="Memory")),
             Volume(name="tmp-volume-dashboard", emptyDir=EmptyDirVolumeSource()),
         ]
@@ -226,24 +214,12 @@ class KubernetesDashboardCharm(CharmBase):
     @property
     def _dashboard_volume_mounts(self) -> List[VolumeMount]:
         """Returns the additional volume mounts for the dashboard containers."""
-        return [
-            VolumeMount(mountPath="/tmp", name="tmp-volume-dashboard"),
-            VolumeMount(
-                mountPath="/var/run/secrets/kubernetes.io/serviceaccount",
-                name="kubernetes-dashboard-service-account",
-            ),
-        ]
+        return [VolumeMount(mountPath="/tmp", name="tmp-volume-dashboard")]
 
     @property
     def _metrics_scraper_volume_mounts(self) -> List[VolumeMount]:
         """Returns the additional volume mounts for the scraper containers."""
-        return [
-            VolumeMount(mountPath="/tmp", name="tmp-volume-metrics"),
-            VolumeMount(
-                mountPath="/var/run/secrets/kubernetes.io/serviceaccount",
-                name="kubernetes-dashboard-service-account",
-            ),
-        ]
+        return [VolumeMount(mountPath="/tmp", name="tmp-volume-metrics")]
 
     @property
     def _statefulset_patched(self) -> bool:
@@ -266,4 +242,4 @@ class KubernetesDashboardCharm(CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(KubernetesDashboardCharm, use_juju_for_storage=True)
+    main(KubernetesDashboardCharm)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -42,13 +42,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     )
 
     # issuing dummy update_status just to trigger an event
-    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
-
-    await ops_test.model.wait_for_idle(apps=["dashboard"], status="active", timeout=1000)
-    assert ops_test.model.applications["dashboard"].units[0].workload_status == "active"
-
-    # effectively disable the update status from firing
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=["dashboard"], status="active", timeout=1000)
+        assert ops_test.model.applications["dashboard"].units[0].workload_status == "active"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import ops.testing
+
+ops.testing.SIMULATE_CAN_CONNECT = True


### PR DESCRIPTION
This PR:

- Updates the dashboard and metrics scraper containers to the latest versions
- Bumps the versions of the charmcraft libs (`kubernetes_service_patch`)
- Updates the CI to include automated releasing