### PR TITLE
chore: bump dashboard version

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
+        uses: canonical/charming-actions/check-libraries@2.0.0-rc2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -50,11 +50,4 @@ jobs:
         with:
           provider: microk8s
       - name: Run integration tests
-        # set a predictable model name so it can be consumed by charm-logdump-action
-        run: tox -e integration -- --model testing
-      - name: Dump logs
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: kubernetes-dashboard
-          model: dashboard
+        run: tox -e integration

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
+        uses: canonical/charming-actions/check-libraries@2.0.0-rc2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -53,14 +53,7 @@ jobs:
         with:
           provider: microk8s
       - name: Run integration tests
-        # set a predictable model name so it can be consumed by charm-logdump-action
-        run: tox -e integration -- --model testing
-      - name: Dump logs
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: kubernetes-dashboard
-          model: dashboard
+        run: tox -e integration
 
   release-to-charmhub:
     name: Release to CharmHub
@@ -76,10 +69,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@1.0.3
+        uses: canonical/charming-actions/channel@2.0.0-rc2
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@1.0.3
+        uses: canonical/charming-actions/upload-charm@2.0.0-rc2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,7 @@ resources:
   dashboard-image:
     type: oci-image
     description: OCI image for kubernetesui/dashboard
-    upstream-source: kubernetesui/dashboard:v2.6.0
+    upstream-source: kubernetesui/dashboard:v2.6.1
   scraper-image:
     type: oci-image
     description: OCI image for kubernetesui/metrics-scraper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
Match the upstream release: https://github.com/kubernetes/dashboard/releases/tag/v2.6.1