### PR TITLE
chore: update base to 22.04

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,10 +5,10 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
 parts:
   charm:
     charm-python-packages: [setuptools, pip]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -38,7 +38,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         "scraper-image": METADATA["resources"]["scraper-image"]["upstream-source"],
     }
     await ops_test.model.deploy(
-        charm, resources=resources, application_name="dashboard", trust=True
+        charm, resources=resources, application_name="dashboard", trust=True, series="jammy"
     )
 
     # issuing dummy update_status just to trigger an event


### PR DESCRIPTION
Update the charm's build and run base to use Ubuntu 22.04