### PR TITLE
ci: test 3.1/edge for SIGTERM bug; remove custom handler

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.26-strict/stable
-          juju-channel: 3.1/stable
+          juju-channel: 3.1/edge
           microk8s-group: snap_microk8s
       - name: Run integration tests
         run: tox -e integration

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,9 +6,6 @@
 
 import datetime
 import logging
-import os
-import signal
-import sys
 import traceback
 from glob import glob
 from ipaddress import IPv4Address
@@ -243,12 +240,5 @@ class KubernetesDashboardCharm(CharmBase):
         return IPv4Address(check_output(["unit-get", "private-address"]).decode().strip())
 
 
-# Workaround for Error status after the StatefulSet is patched in the pebble-ready hook
-def _signal_worker(*args) -> None:
-    os.kill(os.getppid(), signal.SIGTERM)
-    sys.exit(0)
-
-
 if __name__ == "__main__":  # pragma: nocover
-    signal.signal(signal.SIGTERM, _signal_worker)
     main(KubernetesDashboardCharm)


### PR DESCRIPTION
Test a fix for the SIGTERM/error state transition in deploying charms that modify the statefulset juju creates.