### PR TITLE
integrate with the tls certificates relation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv/
 .coverage
 **/__pycache__/
 .tox
+juju-crashdump*

--- a/.jujuignore
+++ b/.jujuignore
@@ -1,3 +1,4 @@
 /venv
 *.py[cod]
 *.charm
+juju-crashdump*

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -52,6 +52,7 @@ parts:
   charm:
     charm-python-packages: [setuptools, pip]
     build-packages:
+      - git
       - libffi-dev
       - libssl-dev
       - pkg-config

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -4,19 +4,56 @@
 type: charm
 bases:
   - build-on:
-    - name: ubuntu
-      channel: "20.04"
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["amd64"]
     run-on:
-    - name: ubuntu
-      channel: "20.04"
+    - name: "ubuntu"
+      channel: "22.04"
       architectures:
         - amd64
-        - arm64
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["armhf"]
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures:
         - armhf
-        - ppc64
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["arm64"]
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures:
+        - arm64
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["ppc64el"]
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures:
+        - ppc64el
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures: ["s390x"]
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+      architectures:
         - s390x
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
     build-packages:
-      - git
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
+      - rustc
+      - cargo

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1,0 +1,1570 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Library for the tls-certificates relation.
+
+This library contains the Requires and Provides classes for handling the tls-certificates
+interface.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.tls_certificates_interface.v2.tls_certificates
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- jsonschema
+- cryptography
+
+Add the following section to the charm's `charmcraft.yaml` file:
+```yaml
+parts:
+  charm:
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - rustc
+      - cargo
+```
+
+### Provider charm
+The provider charm is the charm providing certificates to another charm that requires them. In
+this example, the provider charm is storing its private key using a peer relation interface called
+`replicas`.
+
+Example:
+```python
+from charms.tls_certificates_interface.v2.tls_certificates import (
+    CertificateCreationRequestEvent,
+    CertificateRevocationRequestEvent,
+    TLSCertificatesProvidesV2,
+    generate_private_key,
+)
+from ops.charm import CharmBase, InstallEvent
+from ops.main import main
+from ops.model import ActiveStatus, WaitingStatus
+
+
+def generate_ca(private_key: bytes, subject: str) -> str:
+    return "whatever ca content"
+
+
+def generate_certificate(ca: str, private_key: str, csr: str) -> str:
+    return "Whatever certificate"
+
+
+class ExampleProviderCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificates = TLSCertificatesProvidesV2(self, "certificates")
+        self.framework.observe(
+            self.certificates.on.certificate_request,
+            self._on_certificate_request
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_revocation_request,
+            self._on_certificate_revocation_request
+        )
+        self.framework.observe(self.on.install, self._on_install)
+
+    def _on_install(self, event: InstallEvent) -> None:
+        private_key_password = b"banana"
+        private_key = generate_private_key(password=private_key_password)
+        ca_certificate = generate_ca(private_key=private_key, subject="whatever")
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update(
+            {
+                "private_key_password": "banana",
+                "private_key": private_key,
+                "ca_certificate": ca_certificate,
+            }
+        )
+        self.unit.status = ActiveStatus()
+
+    def _on_certificate_request(self, event: CertificateCreationRequestEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        ca_certificate = replicas_relation.data[self.app].get("ca_certificate")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        certificate = generate_certificate(
+            ca=ca_certificate,
+            private_key=private_key,
+            csr=event.certificate_signing_request,
+        )
+
+        self.certificates.set_relation_certificate(
+            certificate=certificate,
+            certificate_signing_request=event.certificate_signing_request,
+            ca=ca_certificate,
+            chain=[ca_certificate, certificate],
+            relation_id=event.relation_id,
+        )
+
+    def _on_certificate_revocation_request(self, event: CertificateRevocationRequestEvent) -> None:
+        # Do what you want to do with this information
+        pass
+
+
+if __name__ == "__main__":
+    main(ExampleProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the charm requiring certificates from another charm that provides them. In
+this example, the requirer charm is storing its certificates using a peer relation interface called
+`replicas`.
+
+Example:
+```python
+from charms.tls_certificates_interface.v2.tls_certificates import (
+    CertificateAvailableEvent,
+    CertificateExpiringEvent,
+    CertificateRevokedEvent,
+    TLSCertificatesRequiresV2,
+    generate_csr,
+    generate_private_key,
+)
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+from ops.model import ActiveStatus, WaitingStatus
+from typing import Union
+
+
+class ExampleRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.cert_subject = "whatever"
+        self.certificates = TLSCertificatesRequiresV2(self, "certificates")
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_available, self._on_certificate_available
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_expiring, self._on_certificate_expiring
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_invalidated, self._on_certificate_invalidated
+        )
+        self.framework.observe(
+            self.certificates.on.all_certificates_invalidated,
+            self._on_all_certificates_invalidated
+        )
+
+    def _on_install(self, event) -> None:
+        private_key_password = b"banana"
+        private_key = generate_private_key(password=private_key_password)
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update(
+            {"private_key_password": "banana", "private_key": private_key.decode()}
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject=self.cert_subject,
+        )
+        replicas_relation.data[self.app].update({"csr": csr.decode()})
+        self.certificates.request_certificate_creation(certificate_signing_request=csr)
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update({"certificate": event.certificate})
+        replicas_relation.data[self.app].update({"ca": event.ca})
+        replicas_relation.data[self.app].update({"chain": event.chain})
+        self.unit.status = ActiveStatus()
+
+    def _on_certificate_expiring(
+        self, event: Union[CertificateExpiringEvent, CertificateInvalidatedEvent]
+    ) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        old_csr = replicas_relation.data[self.app].get("csr")
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        new_csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject=self.cert_subject,
+        )
+        self.certificates.request_certificate_renewal(
+            old_certificate_signing_request=old_csr,
+            new_certificate_signing_request=new_csr,
+        )
+        replicas_relation.data[self.app].update({"csr": new_csr.decode()})
+
+    def _certificate_revoked(self) -> None:
+        old_csr = replicas_relation.data[self.app].get("csr")
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        new_csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject=self.cert_subject,
+        )
+        self.certificates.request_certificate_renewal(
+            old_certificate_signing_request=old_csr,
+            new_certificate_signing_request=new_csr,
+        )
+        replicas_relation.data[self.app].update({"csr": new_csr.decode()})
+        replicas_relation.data[self.app].pop("certificate")
+        replicas_relation.data[self.app].pop("ca")
+        replicas_relation.data[self.app].pop("chain")
+        self.unit.status = WaitingStatus("Waiting for new certificate")
+
+    def _on_certificate_invalidated(self, event: CertificateInvalidatedEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        if event.reason == "revoked":
+            self._certificate_revoked()
+        if event.reason == "expired":
+            self._on_certificate_expiring(event)
+
+    def _on_all_certificates_invalidated(self, event: AllCertificatesInvalidatedEvent) -> None:
+        # Do what you want with this information, probably remove all certificates.
+        pass
+
+
+if __name__ == "__main__":
+    main(ExampleRequirerCharm)
+```
+
+You can relate both charms by running:
+
+```bash
+juju relate <tls-certificates provider charm> <tls-certificates requirer charm>
+```
+
+"""  # noqa: D405, D410, D411, D214, D416
+
+import copy
+import json
+import logging
+import uuid
+from collections import defaultdict
+from contextlib import suppress
+from datetime import datetime, timedelta
+from ipaddress import IPv4Address
+from typing import Any, Dict, List, Literal, Optional
+
+from cryptography import x509
+from cryptography.hazmat._oid import ExtensionOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.x509.extensions import Extension, ExtensionNotFound
+from jsonschema import exceptions, validate  # type: ignore[import]
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    SecretExpiredEvent,
+    UpdateStatusEvent,
+)
+from ops.framework import EventBase, EventSource, Handle, Object
+from ops.jujuversion import JujuVersion
+from ops.model import SecretNotFoundError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "afd8c2bccf834997afce12c2706d2ede"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 2
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 9
+
+PYDEPS = ["cryptography", "jsonschema"]
+
+REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/requirer.json",  # noqa: E501
+    "type": "object",
+    "title": "`tls_certificates` requirer root schema",
+    "description": "The `tls_certificates` root schema comprises the entire requirer databag for this interface.",  # noqa: E501
+    "examples": [
+        {
+            "certificate_signing_requests": [
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\\n-----END CERTIFICATE REQUEST-----\\n"  # noqa: E501
+                },
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\\nAQEBBQADggEPADCCAQoCggEBAMk3raaX803cHvzlBF9LC7KORT46z4VjyU5PIaMb\\nQLIDgYKFYI0n5hf2Ra4FAHvOvEmW7bjNlHORFEmvnpcU5kPMNUyKFMTaC8LGmN8z\\nUBH3aK+0+FRvY4afn9tgj5435WqOG9QdoDJ0TJkjJbJI9M70UOgL711oU7ql6HxU\\n4d2ydFK9xAHrBwziNHgNZ72L95s4gLTXf0fAHYf15mDA9U5yc+YDubCKgTXzVySQ\\nUx73VCJLfC/XkZIh559IrnRv5G9fu6BMLEuBwAz6QAO4+/XidbKWN4r2XSq5qX4n\\n6EPQQWP8/nd4myq1kbg6Q8w68L/0YdfjCmbyf2TuoWeImdUCAwEAAaAAMA0GCSqG\\nSIb3DQEBCwUAA4IBAQBIdwraBvpYo/rl5MH1+1Um6HRg4gOdQPY5WcJy9B9tgzJz\\nittRSlRGTnhyIo6fHgq9KHrmUthNe8mMTDailKFeaqkVNVvk7l0d1/B90Kz6OfmD\\nxN0qjW53oP7y3QB5FFBM8DjqjmUnz5UePKoX4AKkDyrKWxMwGX5RoET8c/y0y9jp\\nvSq3Wh5UpaZdWbe1oVY8CqMVUEVQL2DPjtopxXFz2qACwsXkQZxWmjvZnRiP8nP8\\nbdFaEuh9Q6rZ2QdZDEtrU4AodPU3NaukFr5KlTUQt3w/cl+5//zils6G5zUWJ2pN\\ng7+t9PTvXHRkH+LnwaVnmsBFU2e05qADQbfIn7JA\\n-----END CERTIFICATE REQUEST-----\\n"  # noqa: E501
+                },
+            ]
+        }
+    ],
+    "properties": {
+        "certificate_signing_requests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"certificate_signing_request": {"type": "string"}},
+                "required": ["certificate_signing_request"],
+            },
+        }
+    },
+    "required": ["certificate_signing_requests"],
+    "additionalProperties": True,
+}
+
+PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/provider.json",  # noqa: E501
+    "type": "object",
+    "title": "`tls_certificates` provider root schema",
+    "description": "The `tls_certificates` root schema comprises the entire provider databag for this interface.",  # noqa: E501
+    "examples": [
+        {
+            "certificates": [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n",  # noqa: E501
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n"  # noqa: E501, W505
+                    ],
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\n-----END CERTIFICATE REQUEST-----\n",  # noqa: E501
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
+                }
+            ]
+        },
+        {
+            "certificates": [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n",  # noqa: E501
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n"  # noqa: E501, W505
+                    ],
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\n-----END CERTIFICATE REQUEST-----\n",  # noqa: E501
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
+                    "revoked": True,
+                }
+            ]
+        },
+    ],
+    "properties": {
+        "certificates": {
+            "$id": "#/properties/certificates",
+            "type": "array",
+            "items": {
+                "$id": "#/properties/certificates/items",
+                "type": "object",
+                "required": ["certificate_signing_request", "certificate", "ca", "chain"],
+                "properties": {
+                    "certificate_signing_request": {
+                        "$id": "#/properties/certificates/items/certificate_signing_request",
+                        "type": "string",
+                    },
+                    "certificate": {
+                        "$id": "#/properties/certificates/items/certificate",
+                        "type": "string",
+                    },
+                    "ca": {"$id": "#/properties/certificates/items/ca", "type": "string"},
+                    "chain": {
+                        "$id": "#/properties/certificates/items/chain",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "$id": "#/properties/certificates/items/chain/items",
+                        },
+                    },
+                    "revoked": {
+                        "$id": "#/properties/certificates/items/revoked",
+                        "type": "boolean",
+                    },
+                },
+                "additionalProperties": True,
+            },
+        }
+    },
+    "required": ["certificates"],
+    "additionalProperties": True,
+}
+
+
+logger = logging.getLogger(__name__)
+
+
+class CertificateAvailableEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is available."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate": self.certificate,
+            "certificate_signing_request": self.certificate_signing_request,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+class CertificateExpiringEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is almost expired."""
+
+    def __init__(self, handle, certificate: str, expiry: str):
+        """CertificateExpiringEvent.
+
+        Args:
+            handle (Handle): Juju framework handle
+            certificate (str): TLS Certificate
+            expiry (str): Datetime string representing the time at which the certificate
+                won't be valid anymore.
+        """
+        super().__init__(handle)
+        self.certificate = certificate
+        self.expiry = expiry
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {"certificate": self.certificate, "expiry": self.expiry}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.expiry = snapshot["expiry"]
+
+
+class CertificateInvalidatedEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is invalidated."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        reason: Literal["expired", "revoked"],
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+    ):
+        super().__init__(handle)
+        self.reason = reason
+        self.certificate_signing_request = certificate_signing_request
+        self.certificate = certificate
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "reason": self.reason,
+            "certificate_signing_request": self.certificate_signing_request,
+            "certificate": self.certificate,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.reason = snapshot["reason"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.certificate = snapshot["certificate"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+class AllCertificatesInvalidatedEvent(EventBase):
+    """Charm Event triggered when all TLS certificates are invalidated."""
+
+    def __init__(self, handle: Handle):
+        super().__init__(handle)
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        pass
+
+
+class CertificateCreationRequestEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is required."""
+
+    def __init__(self, handle: Handle, certificate_signing_request: str, relation_id: int):
+        super().__init__(handle)
+        self.certificate_signing_request = certificate_signing_request
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate_signing_request": self.certificate_signing_request,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificateRevocationRequestEvent(EventBase):
+    """Charm Event triggered when a TLS certificate needs to be revoked."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: str,
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate": self.certificate,
+            "certificate_signing_request": self.certificate_signing_request,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+def _load_relation_data(raw_relation_data: dict) -> dict:
+    """Loads relation data from the relation data bag.
+
+    Json loads all data.
+
+    Args:
+        raw_relation_data: Relation data from the databag
+
+    Returns:
+        dict: Relation data in dict format.
+    """
+    certificate_data = dict()
+    for key in raw_relation_data:
+        try:
+            certificate_data[key] = json.loads(raw_relation_data[key])
+        except (json.decoder.JSONDecodeError, TypeError):
+            certificate_data[key] = raw_relation_data[key]
+    return certificate_data
+
+
+def generate_ca(
+    private_key: bytes,
+    subject: str,
+    private_key_password: Optional[bytes] = None,
+    validity: int = 365,
+    country: str = "US",
+) -> bytes:
+    """Generates a CA Certificate.
+
+    Args:
+        private_key (bytes): Private key
+        subject (str): Certificate subject
+        private_key_password (bytes): Private key password
+        validity (int): Certificate validity time (in days)
+        country (str): Certificate Issuing country
+
+    Returns:
+        bytes: CA Certificate.
+    """
+    private_key_object = serialization.load_pem_private_key(
+        private_key, password=private_key_password
+    )
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
+            x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
+        ]
+    )
+    subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
+        private_key_object.public_key()  # type: ignore[arg-type]
+    )
+    subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key_object.public_key())  # type: ignore[arg-type]
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def generate_certificate(
+    csr: bytes,
+    ca: bytes,
+    ca_key: bytes,
+    ca_key_password: Optional[bytes] = None,
+    validity: int = 365,
+    alt_names: Optional[List[str]] = None,
+) -> bytes:
+    """Generates a TLS certificate based on a CSR.
+
+    Args:
+        csr (bytes): CSR
+        ca (bytes): CA Certificate
+        ca_key (bytes): CA private key
+        ca_key_password: CA private key password
+        validity (int): Certificate validity (in days)
+        alt_names (list): List of alt names to put on cert - prefer putting SANs in CSR
+
+    Returns:
+        bytes: Certificate
+    """
+    csr_object = x509.load_pem_x509_csr(csr)
+    subject = csr_object.subject
+    issuer = x509.load_pem_x509_certificate(ca).issuer
+    private_key = serialization.load_pem_private_key(ca_key, password=ca_key_password)
+
+    certificate_builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(csr_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+    )
+
+    extensions_list = csr_object.extensions
+    san_ext: Optional[x509.Extension] = None
+    if alt_names:
+        full_sans_dns = alt_names.copy()
+        try:
+            loaded_san_ext = csr_object.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            )
+            full_sans_dns.extend(loaded_san_ext.value.get_values_for_type(x509.DNSName))
+        except ExtensionNotFound:
+            pass
+        finally:
+            san_ext = Extension(
+                ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+                False,
+                x509.SubjectAlternativeName([x509.DNSName(name) for name in full_sans_dns]),
+            )
+            if not extensions_list:
+                extensions_list = x509.Extensions([san_ext])
+
+    for extension in extensions_list:
+        if extension.value.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME and san_ext:
+            extension = san_ext
+
+        certificate_builder = certificate_builder.add_extension(
+            extension.value,
+            critical=extension.critical,
+        )
+    certificate_builder._version = x509.Version.v3
+    cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def generate_pfx_package(
+    certificate: bytes,
+    private_key: bytes,
+    package_password: str,
+    private_key_password: Optional[bytes] = None,
+) -> bytes:
+    """Generates a PFX package to contain the TLS certificate and private key.
+
+    Args:
+        certificate (bytes): TLS certificate
+        private_key (bytes): Private key
+        package_password (str): Password to open the PFX package
+        private_key_password (bytes): Private key password
+
+    Returns:
+        bytes:
+    """
+    private_key_object = serialization.load_pem_private_key(
+        private_key, password=private_key_password
+    )
+    certificate_object = x509.load_pem_x509_certificate(certificate)
+    name = certificate_object.subject.rfc4514_string()
+    pfx_bytes = pkcs12.serialize_key_and_certificates(
+        name=name.encode(),
+        cert=certificate_object,
+        key=private_key_object,  # type: ignore[arg-type]
+        cas=None,
+        encryption_algorithm=serialization.BestAvailableEncryption(package_password.encode()),
+    )
+    return pfx_bytes
+
+
+def generate_private_key(
+    password: Optional[bytes] = None,
+    key_size: int = 2048,
+    public_exponent: int = 65537,
+) -> bytes:
+    """Generates a private key.
+
+    Args:
+        password (bytes): Password for decrypting the private key
+        key_size (int): Key size in bytes
+        public_exponent: Public exponent.
+
+    Returns:
+        bytes: Private Key
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=public_exponent,
+        key_size=key_size,
+    )
+    key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.BestAvailableEncryption(password)
+        if password
+        else serialization.NoEncryption(),
+    )
+    return key_bytes
+
+
+def generate_csr(
+    private_key: bytes,
+    subject: str,
+    add_unique_id_to_subject_name: bool = True,
+    organization: Optional[str] = None,
+    email_address: Optional[str] = None,
+    country_name: Optional[str] = None,
+    private_key_password: Optional[bytes] = None,
+    sans: Optional[List[str]] = None,
+    sans_oid: Optional[List[str]] = None,
+    sans_ip: Optional[List[str]] = None,
+    sans_dns: Optional[List[str]] = None,
+    additional_critical_extensions: Optional[List] = None,
+) -> bytes:
+    """Generates a CSR using private key and subject.
+
+    Args:
+        private_key (bytes): Private key
+        subject (str): CSR Subject.
+        add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
+            subject name. Always leave to "True" when the CSR is used to request certificates
+            using the tls-certificates relation.
+        organization (str): Name of organization.
+        email_address (str): Email address.
+        country_name (str): Country Name.
+        private_key_password (bytes): Private key password
+        sans (list): Use sans_dns - this will be deprecated in a future release
+            List of DNS subject alternative names (keeping it for now for backward compatibility)
+        sans_oid (list): List of registered ID SANs
+        sans_dns (list): List of DNS subject alternative names (similar to the arg: sans)
+        sans_ip (list): List of IP subject alternative names
+        additional_critical_extensions (list): List if critical additional extension objects.
+            Object must be a x509 ExtensionType.
+
+    Returns:
+        bytes: CSR
+    """
+    signing_key = serialization.load_pem_private_key(private_key, password=private_key_password)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, subject)]
+    if add_unique_id_to_subject_name:
+        unique_identifier = uuid.uuid4()
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.X500_UNIQUE_IDENTIFIER, str(unique_identifier))
+        )
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
+
+    _sans: List[x509.GeneralName] = []
+    if sans_oid:
+        _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
+    if sans_ip:
+        _sans.extend([x509.IPAddress(IPv4Address(san)) for san in sans_ip])
+    if sans:
+        _sans.extend([x509.DNSName(san) for san in sans])
+    if sans_dns:
+        _sans.extend([x509.DNSName(san) for san in sans_dns])
+    if _sans:
+        csr = csr.add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
+
+    if additional_critical_extensions:
+        for extension in additional_critical_extensions:
+            csr = csr.add_extension(extension, critical=True)
+
+    signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    return signed_certificate.public_bytes(serialization.Encoding.PEM)
+
+
+class CertificatesProviderCharmEvents(CharmEvents):
+    """List of events that the TLS Certificates provider charm can leverage."""
+
+    certificate_creation_request = EventSource(CertificateCreationRequestEvent)
+    certificate_revocation_request = EventSource(CertificateRevocationRequestEvent)
+
+
+class CertificatesRequirerCharmEvents(CharmEvents):
+    """List of events that the TLS Certificates requirer charm can leverage."""
+
+    certificate_available = EventSource(CertificateAvailableEvent)
+    certificate_expiring = EventSource(CertificateExpiringEvent)
+    certificate_invalidated = EventSource(CertificateInvalidatedEvent)
+    all_certificates_invalidated = EventSource(AllCertificatesInvalidatedEvent)
+
+
+class TLSCertificatesProvidesV2(Object):
+    """TLS certificates provider class to be instantiated by TLS certificates providers."""
+
+    on = CertificatesProviderCharmEvents()
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def _add_certificate(
+        self,
+        relation_id: int,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+    ) -> None:
+        """Adds certificate to relation data.
+
+        Args:
+            relation_id (int): Relation id
+            certificate (str): Certificate
+            certificate_signing_request (str): Certificate Signing Request
+            ca (str): CA Certificate
+            chain (list): CA Chain
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=relation_id
+        )
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+        new_certificate = {
+            "certificate": certificate,
+            "certificate_signing_request": certificate_signing_request,
+            "ca": ca,
+            "chain": chain,
+        }
+        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_certificates = provider_relation_data.get("certificates", [])
+        certificates = copy.deepcopy(provider_certificates)
+        if new_certificate in certificates:
+            logger.info("Certificate already in relation data - Doing nothing")
+            return
+        certificates.append(new_certificate)
+        relation.data[self.model.app]["certificates"] = json.dumps(certificates)
+
+    def _remove_certificate(
+        self,
+        relation_id: int,
+        certificate: Optional[str] = None,
+        certificate_signing_request: Optional[str] = None,
+    ) -> None:
+        """Removes certificate from a given relation based on user provided certificate or csr.
+
+        Args:
+            relation_id (int): Relation id
+            certificate (str): Certificate (optional)
+            certificate_signing_request: Certificate signing request (optional)
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} with relation id {relation_id} does not exist"
+            )
+        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_certificates = provider_relation_data.get("certificates", [])
+        certificates = copy.deepcopy(provider_certificates)
+        for certificate_dict in certificates:
+            if certificate and certificate_dict["certificate"] == certificate:
+                certificates.remove(certificate_dict)
+            if (
+                certificate_signing_request
+                and certificate_dict["certificate_signing_request"] == certificate_signing_request
+            ):
+                certificates.remove(certificate_dict)
+        relation.data[self.model.app]["certificates"] = json.dumps(certificates)
+
+    @staticmethod
+    def _relation_data_is_valid(certificates_data: dict) -> bool:
+        """Uses JSON schema validator to validate relation data content.
+
+        Args:
+            certificates_data (dict): Certificate data dictionary as retrieved from relation data.
+
+        Returns:
+            bool: True/False depending on whether the relation data follows the json schema.
+        """
+        try:
+            validate(instance=certificates_data, schema=REQUIRER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def revoke_all_certificates(self) -> None:
+        """Revokes all certificates of this provider.
+
+        This method is meant to be used when the Root CA has changed.
+        """
+        for relation in self.model.relations[self.relationship_name]:
+            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_certificates = copy.deepcopy(provider_relation_data.get("certificates", []))
+            for certificate in provider_certificates:
+                certificate["revoked"] = True
+            relation.data[self.model.app]["certificates"] = json.dumps(provider_certificates)
+
+    def set_relation_certificate(
+        self,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+        relation_id: int,
+    ) -> None:
+        """Adds certificates to relation data.
+
+        Args:
+            certificate (str): Certificate
+            certificate_signing_request (str): Certificate signing request
+            ca (str): CA Certificate
+            chain (list): CA Chain
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        if not self.model.unit.is_leader():
+            return
+        certificates_relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=relation_id
+        )
+        if not certificates_relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        self._remove_certificate(
+            certificate_signing_request=certificate_signing_request.strip(),
+            relation_id=relation_id,
+        )
+        self._add_certificate(
+            relation_id=relation_id,
+            certificate=certificate.strip(),
+            certificate_signing_request=certificate_signing_request.strip(),
+            ca=ca.strip(),
+            chain=[cert.strip() for cert in chain],
+        )
+
+    def remove_certificate(self, certificate: str) -> None:
+        """Removes a given certificate from relation data.
+
+        Args:
+            certificate (str): TLS Certificate
+
+        Returns:
+            None
+        """
+        certificates_relation = self.model.relations[self.relationship_name]
+        if not certificates_relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        for certificate_relation in certificates_relation:
+            self._remove_certificate(certificate=certificate, relation_id=certificate_relation.id)
+
+    def get_issued_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> Dict[str, Dict[str, str]]:
+        """Returns a dictionary of issued certificates.
+
+        It returns certificates from all relations if relation_id is not specified.
+        Certificates are returned per application name and CSR.
+
+        Returns:
+            dict: Certificates per application name.
+        """
+        certificates: Dict[str, Dict[str, str]] = defaultdict(dict)
+        relations = (
+            [self.model.relations[self.relationship_name][relation_id]]
+            if relation_id
+            else self.model.relations.get(self.relationship_name, [])
+        )
+        for relation in relations:
+            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_certificates = provider_relation_data.get("certificates", [])
+            for certificate in provider_certificates:
+                certificates[relation.app.name].update(  # type: ignore[union-attr]
+                    {certificate["certificate_signing_request"]: certificate["certificate"]}
+                )
+        return certificates
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handler triggered on relation changed event.
+
+        Looks at the relation data and either emits:
+        - certificate request event: If the unit relation data contains a CSR for which
+            a certificate does not exist in the provider relation data.
+        - certificate revocation event: If the provider relation data contains a CSR for which
+            a csr does not exist in the requirer relation data.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        assert event.unit is not None
+        requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
+        provider_relation_data = _load_relation_data(event.relation.data[self.charm.app])
+        if not self._relation_data_is_valid(requirer_relation_data):
+            logger.debug("Relation data did not pass JSON Schema validation")
+            return
+        provider_certificates = provider_relation_data.get("certificates", [])
+        requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
+        provider_csrs = [
+            certificate_creation_request["certificate_signing_request"]
+            for certificate_creation_request in provider_certificates
+        ]
+        requirer_unit_csrs = [
+            certificate_creation_request["certificate_signing_request"]
+            for certificate_creation_request in requirer_csrs
+        ]
+        for certificate_signing_request in requirer_unit_csrs:
+            if certificate_signing_request not in provider_csrs:
+                self.on.certificate_creation_request.emit(
+                    certificate_signing_request=certificate_signing_request,
+                    relation_id=event.relation.id,
+                )
+        self._revoke_certificates_for_which_no_csr_exists(relation_id=event.relation.id)
+
+    def _revoke_certificates_for_which_no_csr_exists(self, relation_id: int) -> None:
+        """Revokes certificates for which no unit has a CSR.
+
+        Goes through all generated certificates and compare against the list of CSRs for all units
+        of a given relationship.
+
+        Args:
+            relation_id (int): Relation id
+
+        Returns:
+            None
+        """
+        certificates_relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=relation_id
+        )
+        if not certificates_relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        provider_relation_data = _load_relation_data(certificates_relation.data[self.charm.app])
+        list_of_csrs: List[str] = []
+        for unit in certificates_relation.units:
+            requirer_relation_data = _load_relation_data(certificates_relation.data[unit])
+            requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
+            list_of_csrs.extend(csr["certificate_signing_request"] for csr in requirer_csrs)
+        provider_certificates = provider_relation_data.get("certificates", [])
+        for certificate in provider_certificates:
+            if certificate["certificate_signing_request"] not in list_of_csrs:
+                self.on.certificate_revocation_request.emit(
+                    certificate=certificate["certificate"],
+                    certificate_signing_request=certificate["certificate_signing_request"],
+                    ca=certificate["ca"],
+                    chain=certificate["chain"],
+                )
+                self.remove_certificate(certificate=certificate["certificate"])
+
+
+class TLSCertificatesRequiresV2(Object):
+    """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
+
+    on = CertificatesRequirerCharmEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+        expiry_notification_time: int = 168,
+    ):
+        """Generates/use private key and observes relation changed event.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+            expiry_notification_time (int): Time difference between now and expiry (in hours).
+                Used to trigger the CertificateExpiring event. Default: 7 days.
+        """
+        super().__init__(charm, relationship_name)
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.expiry_notification_time = expiry_notification_time
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(
+            charm.on[relationship_name].relation_broken, self._on_relation_broken
+        )
+        if JujuVersion.from_environ().has_secrets:
+            self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
+        else:
+            self.framework.observe(charm.on.update_status, self._on_update_status)
+
+    @property
+    def _requirer_csrs(self) -> List[Dict[str, str]]:
+        """Returns list of requirer CSR's from relation data."""
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
+        return requirer_relation_data.get("certificate_signing_requests", [])
+
+    @property
+    def _provider_certificates(self) -> List[Dict[str, str]]:
+        """Returns list of certificates from the provider's relation data."""
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            logger.debug("No relation: %s", self.relationship_name)
+            return []
+        if not relation.app:
+            logger.debug("No remote app in relation: %s", self.relationship_name)
+            return []
+        provider_relation_data = _load_relation_data(relation.data[relation.app])
+        if not self._relation_data_is_valid(provider_relation_data):
+            logger.warning("Provider relation data did not pass JSON Schema validation")
+            return []
+        return provider_relation_data.get("certificates", [])
+
+    def _add_requirer_csr(self, csr: str) -> None:
+        """Adds CSR to relation data.
+
+        Args:
+            csr (str): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+        new_csr_dict = {"certificate_signing_request": csr}
+        if new_csr_dict in self._requirer_csrs:
+            logger.info("CSR already in relation data - Doing nothing")
+            return
+        requirer_csrs = copy.deepcopy(self._requirer_csrs)
+        requirer_csrs.append(new_csr_dict)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+
+    def _remove_requirer_csr(self, csr: str) -> None:
+        """Removes CSR from relation data.
+
+        Args:
+            csr (str): Certificate signing request
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+        requirer_csrs = copy.deepcopy(self._requirer_csrs)
+        csr_dict = {"certificate_signing_request": csr}
+        if csr_dict not in requirer_csrs:
+            logger.info("CSR not in relation data - Doing nothing")
+            return
+        requirer_csrs.remove(csr_dict)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+
+    def request_certificate_creation(self, certificate_signing_request: bytes) -> None:
+        """Request TLS certificate to provider charm.
+
+        Args:
+            certificate_signing_request (bytes): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+        self._add_requirer_csr(certificate_signing_request.decode().strip())
+        logger.info("Certificate request sent to provider")
+
+    def request_certificate_revocation(self, certificate_signing_request: bytes) -> None:
+        """Removes CSR from relation data.
+
+        The provider of this relation is then expected to remove certificates associated to this
+        CSR from the relation data as well and emit a request_certificate_revocation event for the
+        provider charm to interpret.
+
+        Args:
+            certificate_signing_request (bytes): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        self._remove_requirer_csr(certificate_signing_request.decode().strip())
+        logger.info("Certificate revocation sent to provider")
+
+    def request_certificate_renewal(
+        self, old_certificate_signing_request: bytes, new_certificate_signing_request: bytes
+    ) -> None:
+        """Renews certificate.
+
+        Removes old CSR from relation data and adds new one.
+
+        Args:
+            old_certificate_signing_request: Old CSR
+            new_certificate_signing_request: New CSR
+
+        Returns:
+            None
+        """
+        try:
+            self.request_certificate_revocation(
+                certificate_signing_request=old_certificate_signing_request
+            )
+        except RuntimeError:
+            logger.warning("Certificate revocation failed.")
+        self.request_certificate_creation(
+            certificate_signing_request=new_certificate_signing_request
+        )
+        logger.info("Certificate renewal request completed.")
+
+    @staticmethod
+    def _relation_data_is_valid(certificates_data: dict) -> bool:
+        """Checks whether relation data is valid based on json schema.
+
+        Args:
+            certificates_data: Certificate data in dict format.
+
+        Returns:
+            bool: Whether relation data is valid.
+        """
+        try:
+            validate(instance=certificates_data, schema=PROVIDER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handler triggered on relation changed events.
+
+        Goes through all providers certificates that match a requested CSR.
+
+        If the provider certificate is revoked, emit a CertificateInvalidateEvent,
+        otherwise emit a CertificateAvailableEvent.
+
+        When Juju secrets are available, remove the secret for revoked certificate,
+        or add a secret with the correct expiry time for new certificates.
+
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        requirer_csrs = [
+            certificate_creation_request["certificate_signing_request"]
+            for certificate_creation_request in self._requirer_csrs
+        ]
+        for certificate in self._provider_certificates:
+            if certificate["certificate_signing_request"] in requirer_csrs:
+                if certificate.get("revoked", False):
+                    if JujuVersion.from_environ().has_secrets:
+                        with suppress(SecretNotFoundError):
+                            secret = self.model.get_secret(
+                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
+                            )
+                            secret.remove_all_revisions()
+                    self.on.certificate_invalidated.emit(
+                        reason="revoked",
+                        certificate=certificate["certificate"],
+                        certificate_signing_request=certificate["certificate_signing_request"],
+                        ca=certificate["ca"],
+                        chain=certificate["chain"],
+                    )
+                else:
+                    if JujuVersion.from_environ().has_secrets:
+                        try:
+                            secret = self.model.get_secret(
+                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
+                            )
+                            secret.set_content({"certificate": certificate["certificate"]})
+                            secret.set_info(
+                                expire=self._get_next_secret_expiry_time(
+                                    certificate["certificate"]
+                                ),
+                            )
+                        except SecretNotFoundError:
+                            secret = self.charm.unit.add_secret(
+                                {"certificate": certificate["certificate"]},
+                                label=f"{LIBID}-{certificate['certificate_signing_request']}",
+                                expire=self._get_next_secret_expiry_time(
+                                    certificate["certificate"]
+                                ),
+                            )
+                    self.on.certificate_available.emit(
+                        certificate_signing_request=certificate["certificate_signing_request"],
+                        certificate=certificate["certificate"],
+                        ca=certificate["ca"],
+                        chain=certificate["chain"],
+                    )
+
+    def _get_next_secret_expiry_time(self, certificate: str) -> Optional[datetime]:
+        """Return the expiry time or expiry notification time.
+
+        Extracts the expiry time from the provided certificate, calculates the
+        expiry notification time and return the closest of the two, that is in
+        the future.
+
+        Args:
+            certificate: x509 certificate
+
+        Returns:
+            Optional[datetime]: None if the certificate expiry time cannot be read,
+                                next expiry time otherwise.
+        """
+        expiry_time = _get_certificate_expiry_time(certificate)
+        if not expiry_time:
+            return None
+        expiry_notification_time = expiry_time - timedelta(hours=self.expiry_notification_time)
+        return _get_closest_future_time(expiry_notification_time, expiry_time)
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handler triggered on relation broken event.
+
+        Emitting `all_certificates_invalidated` from `relation-broken` rather
+        than `relation-departed` since certs are stored in app data.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        self.on.all_certificates_invalidated.emit()
+
+    def _on_secret_expired(self, event: SecretExpiredEvent) -> None:
+        """Triggered when a certificate is set to expire.
+
+        Loads the certificate from the secret, and will emit 1 of 2
+        events.
+
+        If the certificate is not yet expired, emits CertificateExpiringEvent
+        and updates the expiry time of the secret to the exact expiry time on
+        the certificate.
+
+        If the certificate is expired, emits CertificateInvalidedEvent and
+        deletes the secret.
+
+        Args:
+            event (SecretExpiredEvent): Juju event
+        """
+        if not event.secret.label or not event.secret.label.startswith(f"{LIBID}-"):
+            return
+        csr = event.secret.label[len(f"{LIBID}-") :]
+        certificate_dict = self._find_certificate_in_relation_data(csr)
+        if not certificate_dict:
+            # A secret expired but we did not find matching certificate. Cleaning up
+            event.secret.remove_all_revisions()
+            return
+
+        expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
+        if not expiry_time:
+            # A secret expired but matching certificate is invalid. Cleaning up
+            event.secret.remove_all_revisions()
+            return
+
+        if datetime.utcnow() < expiry_time:
+            logger.warning("Certificate almost expired")
+            self.on.certificate_expiring.emit(
+                certificate=certificate_dict["certificate"],
+                expiry=expiry_time.isoformat(),
+            )
+            event.secret.set_info(
+                expire=_get_certificate_expiry_time(certificate_dict["certificate"]),
+            )
+        else:
+            logger.warning("Certificate is expired")
+            self.on.certificate_invalidated.emit(
+                reason="expired",
+                certificate=certificate_dict["certificate"],
+                certificate_signing_request=certificate_dict["certificate_signing_request"],
+                ca=certificate_dict["ca"],
+                chain=certificate_dict["chain"],
+            )
+            self.request_certificate_revocation(certificate_dict["certificate"].encode())
+            event.secret.remove_all_revisions()
+
+    def _find_certificate_in_relation_data(self, csr: str) -> Optional[Dict[str, Any]]:
+        """Returns the certificate that match the given CSR."""
+        for certificate_dict in self._provider_certificates:
+            if certificate_dict["certificate_signing_request"] != csr:
+                continue
+            return certificate_dict
+        return None
+
+    def _on_update_status(self, event: UpdateStatusEvent) -> None:
+        """Triggered on update status event.
+
+        Goes through each certificate in the "certificates" relation and checks their expiry date.
+        If they are close to expire (<7 days), emits a CertificateExpiringEvent event and if
+        they are expired, emits a CertificateExpiredEvent.
+
+        Args:
+            event (UpdateStatusEvent): Juju event
+
+        Returns:
+            None
+        """
+        for certificate_dict in self._provider_certificates:
+            expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
+            if not expiry_time:
+                continue
+            time_difference = expiry_time - datetime.utcnow()
+            if time_difference.total_seconds() < 0:
+                logger.warning("Certificate is expired")
+                self.on.certificate_invalidated.emit(
+                    reason="expired",
+                    certificate=certificate_dict["certificate"],
+                    certificate_signing_request=certificate_dict["certificate_signing_request"],
+                    ca=certificate_dict["ca"],
+                    chain=certificate_dict["chain"],
+                )
+                self.request_certificate_revocation(certificate_dict["certificate"].encode())
+                continue
+            if time_difference.total_seconds() < (self.expiry_notification_time * 60 * 60):
+                logger.warning("Certificate almost expired")
+                self.on.certificate_expiring.emit(
+                    certificate=certificate_dict["certificate"],
+                    expiry=expiry_time.isoformat(),
+                )
+
+
+def _get_closest_future_time(
+    expiry_notification_time: datetime, expiry_time: datetime
+) -> datetime:
+    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
+
+    Args:
+        expiry_notification_time (datetime): Notification time of impending expiration
+        expiry_time (datetime): Expiration time
+
+    Returns:
+        datetime: expiry_notification_time if not in the past, expiry_time otherwise
+    """
+    return (
+        expiry_notification_time if datetime.utcnow() < expiry_notification_time else expiry_time
+    )
+
+
+def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
+    """Extract expiry time from a certificate string.
+
+    Args:
+        certificate (str): x509 certificate as a string
+
+    Returns:
+        Optional[datetime]: Expiry datetime or None
+    """
+    try:
+        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+        return certificate_object.not_valid_after
+    except ValueError:
+        logger.warning("Could not load certificate.")
+        return None

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,8 +28,8 @@ resources:
   dashboard-image:
     type: oci-image
     description: OCI image for kubernetesui/dashboard
-    upstream-source: kubernetesui/dashboard:v2.7.0
+    upstream-source: rocks.canonical.com/cdk/kubernetesui/dashboard:v2.7.0
   scraper-image:
     type: oci-image
     description: OCI image for kubernetesui/metrics-scraper
-    upstream-source: kubernetesui/metrics-scraper:v1.0.8
+    upstream-source: rocks.canonical.com/cdk/kubernetesui/metrics-scraper:v1.0.8

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,6 +14,10 @@ description: |
   Dashboard also provides information on the state of Kubernetes resources in your cluster and on
   any errors that may have occurred.
 
+requires:
+  certificates:
+    interface: tls-certificates
+
 containers:
   dashboard:
     resource: dashboard-image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,6 +19,10 @@ requires:
     interface: tls-certificates
     limit: 1
 
+peers:
+  replicas:
+    interface: tls-certificates-replica
+
 containers:
   dashboard:
     resource: dashboard-image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,6 +17,7 @@ description: |
 requires:
   certificates:
     interface: tls-certificates
+    limit: 1
 
 containers:
   dashboard:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-ops==2.4.1
-lightkube==0.14.0
-lightkube-models==1.27.1.4
-Jinja2==3.1.2
+cryptography
+jinja2
+jsonschema
+lightkube
+lightkube-models
+ops
+pydantic<2.0
 git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@339efe3823b9728d16cdf5bcd1fc3b5de4e68923#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ops==2.2.0
-lightkube==0.12.0
+lightkube==0.13.0
 lightkube-models==1.26.0.4
 Jinja2==3.1.2
+git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@61e9f278fc8c8119b1d4810ac39e2275be58e9ce#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ops==2.2.0
-lightkube==0.13.0
-lightkube-models==1.26.0.4
+ops==2.4.1
+lightkube==0.14.0
+lightkube-models==1.27.1.4
 Jinja2==3.1.2
-git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@61e9f278fc8c8119b1d4810ac39e2275be58e9ce#subdirectory=ops
+git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@339efe3823b9728d16cdf5bcd1fc3b5de4e68923#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -185,7 +185,7 @@ class KubernetesDashboardCharm(CharmBase):
             certificate = RelationCert(self.interface_tls, common_name=self._fqdn[0])
             if not certificate.available:
                 logger.info("Requesting TLS certificate for the Kubernetes Dashboard.")
-                certificate.request(sans=self._fqdn + list(map(str,ips)))
+                certificate.request(sans=self._fqdn + list(map(str, ips)))
                 # this will trigger another relation change event
                 return False
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,9 +20,11 @@ from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Service
 from ops.charm import CharmBase, WorkloadEvent
 from ops.framework import StoredState
+from ops.interface_tls_certificates.requires import CertificatesRequires
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import APIError, ChangeError, ConnectionError
+from relation_cert import RelationCert
 
 logger = logging.getLogger(__name__)
 
@@ -34,12 +36,18 @@ class KubernetesDashboardCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self._stored.set_default(dashboard_cmd="")
+
+        self.interface_tls = CertificatesRequires(self)
+        self._stored.set_default(self_signed_cert=True, dashboard_cmd="")
         self._context = {"namespace": self._namespace, "app_name": self.app.name}
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.dashboard_pebble_ready, self._dashboard_pebble_ready)
         self.framework.observe(self.on.scraper_pebble_ready, self._scraper_pebble_ready)
+
+        self.framework.observe(self.on.certificates_relation_created, self._ready_tls)
+        self.framework.observe(self.on.certificates_relation_changed, self._ready_tls)
+        self.framework.observe(self.on.certificates_relation_broken, self._ready_tls)
 
         self._service_patcher = KubernetesServicePatch(self, [("dashboard-https", 443, 8443)])
 
@@ -67,7 +75,36 @@ class KubernetesDashboardCharm(CharmBase):
             event.defer()
             return
 
-        self.unit.status = ActiveStatus()
+        self._evaluate_dashboard_status()
+
+    def _ready_tls(self, event):
+        evaluation = self.interface_tls.evaluate_relation(event)
+        self_sign = True
+        if evaluation and "Waiting" in evaluation:
+            # relation joined, waiting for data
+            self.unit.status = WaitingStatus(evaluation)
+            return
+        elif evaluation is None:
+            # relation joined and ready for accepting requests
+            self_sign = False
+
+        # Apply tls certs changes to the sidecar container
+        container = self.unit.get_container("dashboard")
+        if container.can_connect() and "dashboard" in container.get_services():
+            if self._configure_tls_certs(self_sign):
+                container.restart("dashboard")
+                self._stored.self_signed_cert = self_sign
+            else:
+                self.unit.status = WaitingStatus("Waiting for server certificate")
+                return
+
+        self._evaluate_dashboard_status()
+
+    def _evaluate_dashboard_status(self):
+        container = self.unit.get_container("dashboard")
+        service = container.can_connect() and container.get_services().get("dashboard")
+        if service and service.is_running():
+            self.unit.status = ActiveStatus()
 
     def _scraper_pebble_ready(self, event: WorkloadEvent) -> None:
         """Configure Pebble to start the Kubernetes Metrics Scraper."""
@@ -100,10 +137,9 @@ class KubernetesDashboardCharm(CharmBase):
                 }
                 container.add_layer("dashboard", layer, combine=True)
                 self._stored.dashboard_cmd = cmd
-                self._configure_tls_certs()
                 logger.debug("starting Kubernetes Dashboard with command: '%s'.", cmd)
+                self._configure_tls_certs(self._stored.self_signed_cert)
                 container.start("dashboard")
-                return True
             else:
                 return False
         return True
@@ -122,34 +158,40 @@ class KubernetesDashboardCharm(CharmBase):
         ]
         return " ".join(cmd)
 
-    def _configure_tls_certs(self) -> None:
-        """Create a self-signed certificate for the Dashboard if required."""
-        # TODO: Add a branch here for if a secret is specified in config
+    def _configure_tls_certs(self, self_signed: bool) -> bool:
+        """Load certificates for the Dashboard service."""
         # Make the directory we'll use for certs if it doesn't exist
         container = self.unit.get_container("dashboard")
         container.make_dir("/certs", make_parents=True)
+        refresh = self_signed != self._stored.self_signed_cert
         # If there is already a 'tls.crt', then check its validity/suitability.
-        if "tls.crt" in [x.name for x in container.list_files("/certs")]:
+        if (
+            self_signed
+            and not refresh
+            and "tls.crt" in [x.name for x in container.list_files("/certs")]
+        ):
             # Pull the tls.crt file from the workload container
             cert_bytes = container.pull("/certs/tls.crt")
             # Create an x509 Certificate object with the contents of the file
             if self._validate_certificate(bytes(cert_bytes.read(), encoding="utf-8")):
-                return
+                return True
 
-        # If we get this far, the cert is either not present, or invalid
+        ips = [self._pod_ip, self._svc_ip]
+        if self_signed:
+            # If we get this far, the cert is either not present or needs refreshing
+            logger.info("new self-signed TLS certificate generated for the Kubernetes Dashboard.")
+            certificate = SelfSignedCert(names=self._fqdn, ips=ips)
+        else:
+            certificate = RelationCert(self.interface_tls, common_name=self._fqdn[0])
+            if not certificate.available:
+                logger.info("Requesting TLS certificate for the Kubernetes Dashboard.")
+                certificate.request(sans=self._fqdn + list(map(str,ips)))
+                # this will trigger another relation change event
+                return False
 
-        # Get the cluster IP for the kubernetes service that represents the dashboard
-        client = Client()
-        svc: Service = client.get(Service, self.app.name, namespace=self._namespace)
-        svc_ip = IPv4Address(svc.spec.clusterIP)
-
-        # Generate a valid self-signed certificate, set the Pod IP/Svc IP as SANs
-        fqdn = f"{self.app.name}.{self._namespace}.svc.cluster.local"
-        certificate = SelfSignedCert(names=[fqdn], ips=[self._pod_ip, svc_ip])
-        # Write the generated certificate and key to file
         container.push("/certs/tls.crt", certificate.cert, make_dirs=True)
         container.push("/certs/tls.key", certificate.key, make_dirs=True)
-        logger.info("new self-signed TLS certificate generated for the Kubernetes Dashboard.")
+        return True
 
     def _patch_statefulset(self) -> None:
         """Patch the StatefulSet to include specific ServiceAccount and Secret mounts."""
@@ -238,6 +280,22 @@ class KubernetesDashboardCharm(CharmBase):
     def _pod_ip(self) -> Optional[IPv4Address]:
         """Get the IP address of the Kubernetes pod."""
         return IPv4Address(check_output(["unit-get", "private-address"]).decode().strip())
+
+    @property
+    def _svc_ip(self) -> Optional[IPv4Address]:
+        """Get the IP address of the Kubernetes service."""
+        client = Client()
+        svc: Service = client.get(Service, self.app.name, namespace=self._namespace)
+        return IPv4Address(svc.spec.clusterIP)
+
+    @property
+    def _fqdn(self) -> List[str]:
+        """Get the list of FQDNs to use in cert creation for this service."""
+        return [
+            f"{self.app.name}.{self._namespace}",
+            f"{self.app.name}.{self._namespace}.svc",
+            f"{self.app.name}.{self._namespace}.svc.cluster.local",
+        ]
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/relation_cert.py
+++ b/src/relation_cert.py
@@ -1,39 +1,43 @@
 """Various ways for the admission webhook service to request a TLS cert package."""
 
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional
 
-from ops.interface_tls_certificates.requires import CertificatesRequires
+from ops.interface_tls_certificates import CertificatesRequires
 
 
-class RelationCert:
+@dataclass
+class Certificate:
+    """Representation of a certificate."""
+
+    common_name: str
+    cert: bytes
+    key: bytes
+    ca: bytes
+
+
+class CertificatesRelation:
     """Request certificate package via the tls-interface relation."""
 
-    def __init__(self, relation: CertificatesRequires, common_name: str):
-        self._relation = relation
-        self._common_name = common_name
+    def __init__(self, charm, endpoint: str = "certificates"):
+        self._legacy_relation = CertificatesRequires(charm, endpoint)
 
-    def request(self, sans: List[str]):
+    def request(self, common_name: str, sans: List[str]):
         """Generate certs based on the common_name and sans."""
-        self._relation.request_server_cert(self._common_name, sans)
+        self._legacy_relation.request_server_cert(common_name, sans)
 
     @property
-    def available(self):
+    def relation(self):
+        """Yields the model view of the connected relation."""
+        return self._legacy_relation.relation
+
+    def certificate(self, common_name: str) -> Optional[Certificate]:
         """Cert is available when it appears in the certs map."""
-        return self._common_name in self._relation.server_certs_map
-
-    @property
-    def cert(self) -> bytes:
-        """Representation of a tls certificate."""
-        certificate = self._relation.server_certs_map[self._common_name]
-        return certificate.cert.encode()
-
-    @property
-    def key(self) -> bytes:
-        """Representation of a private key file."""
-        certificate = self._relation.server_certs_map[self._common_name]
-        return certificate.key.encode()
-
-    @property
-    def ca(self) -> bytes:
-        """Representation of a ca cert."""
-        return self._relation.ca.encode()
+        cert_databag = self._legacy_relation.server_certs_map.get(common_name)
+        if cert_databag:
+            return Certificate(
+                common_name,
+                cert_databag.cert.encode(),
+                cert_databag.key.encode(),
+                self._legacy_relation.ca.encode(),
+            )

--- a/src/relation_cert.py
+++ b/src/relation_cert.py
@@ -2,6 +2,7 @@
 
 import logging
 from dataclasses import dataclass
+from functools import cached_property
 from ipaddress import IPv4Address
 from typing import List, Optional
 
@@ -12,7 +13,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (
     generate_private_key,
 )
 from cryptography import x509
-from ops.framework import Object
+from ops.framework import Framework, Object
 from ops.interface_tls_certificates import CertificatesRequires
 from ops.model import RelationDataContent, WaitingStatus
 
@@ -30,40 +31,143 @@ class Certificate:
 
 
 class CertificatesRelation(Object):
-    """Request certificate package via the tls-interface relation."""
+    """Request certificate package via the tls-certificates relation.
 
-    def __init__(self, charm, endpoint: str = "certificates"):
+    This class attempts to unify the tls-certificates proposed by legacy charms
+    such as easyrsa and vault, while adhering to newer schema interfaces proposed
+    by charms such as tls-certificates-operator.
+
+    This class sits as a shim between the main charm code and the two competing
+    versions of the tls-certificates.
+    """
+
+    def __init__(self, charm: Framework, endpoint: str = "certificates"):
+        super().__init__(charm, f"relation-{endpoint}")
+        self._endpoint = endpoint
+
+        # Legacy Relation handles the tls-certificates relation used by easyrsa and vault
+        self._legacy_relation = LegacyRequires(charm, endpoint)
+
+        # Telco Relation handles the tls-certificates relation used by tls-certificates-operator
+        self._telco_relation = TelcoRequires(charm, endpoint)
+
+    @cached_property
+    def relation(self):
+        """The relation to the integrator, or None."""
+        return self.model.get_relation(self._endpoint)
+
+    def install(self, event) -> None:
+        """Run any install events to setup relation handling.
+
+        Only the telco relation has install events passed from the charm.
+        """
+        self._telco_relation.install(event)
+
+    def certificate(self) -> Optional[Certificate]:
+        """Get the certificate from one of the types of relations."""
+        return self._legacy_relation.get_certificate() or self._telco_relation.get_certificate()
+
+    def request(self, names: List[str], ips: List[IPv4Address]) -> None:
+        """Generate certs based on the common_name and sans."""
+        self._legacy_relation.request(names, ips)
+        self._telco_relation.request(names, ips)
+
+
+class LegacyRequires(CertificatesRequires):
+    """Legacy Implementation of the tls-certificates interface."""
+
+    def get_certificate(self):
+        """Cert is available when it appears in the certs map."""
+        if self.is_ready:
+            cert_databag = self.server_certs_map
+            if cert_databag:
+                log.info("Using Certificate from legacy tls-certificates relation.")
+                cert_response, *_ = cert_databag.values()
+                return Certificate(
+                    cert_response.common_name,
+                    cert_response.cert.encode(),
+                    cert_response.key.encode(),
+                    self.ca.encode(),
+                )
+            else:
+                log.info("Didn't find Certificate from legacy tls-certificates relation.")
+                return None
+
+    def request(self, names: List[str], ips: List[IPv4Address]):
+        """Request a Server Certificate based on common_name and sans."""
+        sans = names + [str(_) for _ in ips]
+        log.info(f"Requesting server cert for {sans[0]}")
+        self.request_server_cert(sans[0], sans)
+
+
+class TelcoRequires(Object):
+    """Telco Implementation of the tls-certificates interface."""
+
+    def __init__(self, charm: Framework, endpoint: str):
         super().__init__(charm, f"relation-{endpoint}")
         self._charm = charm
 
-        # Legacy Relation handles the tls-certificates relation used by easyrsa and vault
-        self._legacy_relation = CertificatesRequires(charm, endpoint)
-
-        # Telco Relation handles the tls-certificates relation used by tls-certificates-operator
         self._telco_relation = TLSCertificatesRequiresV2(charm, endpoint)
         on_telco = self._telco_relation.on
 
         self.framework.observe(on_telco.certificate_available, self._on_available)
-        self.framework.observe(on_telco.certificate_expiring, self._on_expiring)
-        self.framework.observe(on_telco.certificate_invalidated, self._on_invalidated)
+        self.framework.observe(on_telco.certificate_expiring, self._on_invalidate)
+        self.framework.observe(on_telco.certificate_invalidated, self._on_invalidate)
+
+    def install(self, event) -> None:
+        """Regenerate the private key on the leader unit on install."""
+        self._regenerate_private_key(self._get_replica_data(event, writable=True))
+
+    def get_certificate(self):
+        """Cert is available when the replicas relation contains the necessary databag."""
+        if not (replica_data := self._get_replica_data(None)):
+            log.warning("Replica data not yet populated.")
+            return None
+
+        csr = replica_data.get("csr")
+        if not csr:
+            log.warning("Have yet to request telco tls-certificate.")
+            return None
+
+        subject, *_ = self._csr_attrs(csr.encode())
+
+        if all(replica_data.get(key) for key in ["certificate", "ca", "chain"]):
+            log.info("Using Certificate from telco tls-certificates relation.")
+            cert = replica_data["certificate"] + "\n" + replica_data["chain"]
+            return Certificate(
+                subject,
+                cert.encode(),
+                replica_data["private_key"].encode(),
+                replica_data["ca"].encode(),
+            )
+        else:
+            log.info("Didn't find Certificate from telco tls-certificates relation.")
+            return None
 
     def request(self, names: List[str], ips: List[IPv4Address]):
-        """Generate certs based on the common_name and sans."""
-        sans = names + [str(_) for _ in ips]
-        log.info(f"Requesting server cert for {sans[0]}")
-        self._legacy_relation.request_server_cert(sans[0], sans)
+        """Request a Server Certificate based on common_name and sans."""
         if replica_data := self._get_replica_data(None, writable=True):
-            private_key = replica_data.get("private_key")
-
-            csr = generate_csr(
-                private_key=private_key.encode(),
-                private_key_password=None,
-                subject=sans[0],
-                sans_dns=names,
-                sans_ip=ips,
-            )
+            csr = self._generate_csr(replica_data, names, ips)
             replica_data.update({"csr": csr.decode()})
             self._telco_relation.request_certificate_creation(certificate_signing_request=csr)
+
+    def _generate_csr(self, replica_data, names=None, ips=None):
+        """Generate Certificate Signing Request for telco relation."""
+        private_key = replica_data.get("private_key").encode()
+
+        if names and ips:
+            subject = names[0]
+        else:
+            old_csr = replica_data.get("csr")
+            subject, names, ips = self._csr_attrs(old_csr)
+
+        return generate_csr(
+            private_key=private_key,
+            private_key_password=None,
+            subject=subject,
+            sans_dns=names,
+            sans_ip=ips,
+        )
 
     def _get_replica_data(self, event, writable=False) -> Optional[RelationDataContent]:
         replicas_relation = self.model.get_relation("replicas")
@@ -87,10 +191,6 @@ class CertificatesRelation(Object):
             data["private_key"] = private_key.decode()
         return private_key
 
-    def install(self, event) -> None:
-        """Regenerate the private key on the leader unit on install."""
-        self._regenerate_private_key(self._get_replica_data(event, writable=True))
-
     def _on_available(self, event: CertificateAvailableEvent):
         if replica_data := self._get_replica_data(event, writable=True):
             replica_data.update(
@@ -103,102 +203,24 @@ class CertificatesRelation(Object):
 
     @staticmethod
     def _csr_attrs(csr: bytes):
+        """Read Subject, Names, and IPs from a CSR."""
         csr_object = x509.load_pem_x509_csr(csr)
         sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName)
         names = sans.value.get_values_for_type(x509.DNSName)
         ips = sans.value.get_values_for_type(x509.IPAddress)
         return csr_object.subject, names, ips
 
-    def _on_expiring(self, event):
+    def _on_invalidate(self, event) -> None:
         if replica_data := self._get_replica_data(event, writable=True):
-            log.info("Current certificate expired, requesting a new one.")
-            private_key = replica_data.get("private_key")
+            log.info(f"Current certificate {event.reason}, requesting a new one.")
             old_csr = replica_data.get("csr")
-            subject, names, ips = self._csr_attrs(old_csr)
-
-            new_csr = generate_csr(
-                private_key=private_key.encode(),
-                private_key_password=None,
-                subject=subject,
-                sans_dns=names,
-                sans_ip=ips,
-            )
+            new_csr = self._generate_csr(replica_data)
             self._telco_relation.request_certificate_renewal(
-                old_certificate_signing_request=old_csr,
+                old_certificate_signing_request=old_csr.encode(),
                 new_certificate_signing_request=new_csr,
             )
             replica_data.update({"csr": new_csr.decode()})
-
-    def _revoke(self, event):
-        if replica_data := self._get_replica_data(event, writable=True):
-            log.info("Current certificate revoked, requesting a new one.")
-            private_key = replica_data.get("private_key")
-            old_csr = replica_data.get("csr").encode()
-            subject, names, ips = self._csr_attrs(old_csr)
-
-            new_csr = generate_csr(
-                private_key=private_key.encode(),
-                private_key_password=None,
-                subject=subject,
-                sans_dns=names,
-                sans_ip=ips,
-            )
-            self._telco_relation.request_certificate_renewal(
-                old_certificate_signing_request=old_csr,
-                new_certificate_signing_request=new_csr,
-            )
-            replica_data.update({"csr": new_csr.decode()})
-            replica_data.pop("certificate")
-            replica_data.pop("ca")
-
-    def _on_invalidated(self, event) -> None:
-        if event.reason == "revoked":
-            self._revoke(event)
-        if event.reason == "expired":
-            self._on_expiring(event)
-
-    @property
-    def relation(self):
-        """Yields the model view of the connected relation."""
-        return self._legacy_relation.relation
-
-    def certificate(self) -> Optional[Certificate]:
-        """Cert is available when it appears in the certs map."""
-        if self._legacy_relation.is_ready:
-            cert_databag = self._legacy_relation.server_certs_map
-            if cert_databag:
-                log.info("Using Certificate from legacy tls-certificates relation.")
-                cert_response, *_ = cert_databag.values()
-                return Certificate(
-                    cert_response.common_name,
-                    cert_response.cert.encode(),
-                    cert_response.key.encode(),
-                    self._legacy_relation.ca.encode(),
-                )
-            else:
-                log.warning("Waiting on Certificate from legacy tls-certificates relation.")
-                return None
-
-        if not (replica_data := self._get_replica_data(None)):
-            log.warning("Replica data not yet populated.")
-            return None
-
-        csr = replica_data.get("csr")
-        if not csr:
-            log.warning("Have yet to request telco tls-certificate.")
-            return None
-
-        subject, *_ = self._csr_attrs(csr.encode())
-
-        if all(replica_data.get(key) for key in ["certificate", "ca"]):
-            log.info("Using Certificate from telco tls-certificates relation.")
-            cert = replica_data["certificate"] + "\n" + replica_data["chain"]
-            return Certificate(
-                subject,
-                cert.encode(),
-                replica_data["private_key"].encode(),
-                replica_data["ca"].encode(),
-            )
-        else:
-            log.warning("Waiting on Certificate from telco tls-certificates relation.")
-            return None
+            if event.reason == "revoked":
+                replica_data.pop("chain")
+                replica_data.pop("certificate")
+                replica_data.pop("ca")

--- a/src/relation_cert.py
+++ b/src/relation_cert.py
@@ -1,9 +1,22 @@
 """Various ways for the admission webhook service to request a TLS cert package."""
 
+import logging
 from dataclasses import dataclass
+from ipaddress import IPv4Address
 from typing import List, Optional
 
+from charms.tls_certificates_interface.v2.tls_certificates import (
+    CertificateAvailableEvent,
+    TLSCertificatesRequiresV2,
+    generate_csr,
+    generate_private_key,
+)
+from cryptography import x509
+from ops.framework import Object
 from ops.interface_tls_certificates import CertificatesRequires
+from ops.model import RelationDataContent, WaitingStatus
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -16,28 +29,176 @@ class Certificate:
     ca: bytes
 
 
-class CertificatesRelation:
+class CertificatesRelation(Object):
     """Request certificate package via the tls-interface relation."""
 
     def __init__(self, charm, endpoint: str = "certificates"):
+        super().__init__(charm, f"relation-{endpoint}")
+        self._charm = charm
+
+        # Legacy Relation handles the tls-certificates relation used by easyrsa and vault
         self._legacy_relation = CertificatesRequires(charm, endpoint)
 
-    def request(self, common_name: str, sans: List[str]):
+        # Telco Relation handles the tls-certificates relation used by tls-certificates-operator
+        self._telco_relation = TLSCertificatesRequiresV2(charm, endpoint)
+        on_telco = self._telco_relation.on
+
+        self.framework.observe(on_telco.certificate_available, self._on_available)
+        self.framework.observe(on_telco.certificate_expiring, self._on_expiring)
+        self.framework.observe(on_telco.certificate_invalidated, self._on_invalidated)
+
+    def request(self, names: List[str], ips: List[IPv4Address]):
         """Generate certs based on the common_name and sans."""
-        self._legacy_relation.request_server_cert(common_name, sans)
+        sans = names + [str(_) for _ in ips]
+        log.info(f"Requesting server cert for {sans[0]}")
+        self._legacy_relation.request_server_cert(sans[0], sans)
+        if replica_data := self._get_replica_data(None, writable=True):
+            private_key = replica_data.get("private_key")
+
+            csr = generate_csr(
+                private_key=private_key.encode(),
+                private_key_password=None,
+                subject=sans[0],
+                sans_dns=names,
+                sans_ip=ips,
+            )
+            replica_data.update({"csr": csr.decode()})
+            self._telco_relation.request_certificate_creation(certificate_signing_request=csr)
+
+    def _get_replica_data(self, event, writable=False) -> Optional[RelationDataContent]:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation and event:
+            self._charm.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return None
+        if writable and not self.model.unit.is_leader():
+            return None
+
+        return replicas_relation.data[self._charm.app]
+
+    def _regenerate_private_key(self, data: Optional[RelationDataContent]) -> Optional[bytes]:
+        if data is None:
+            return None
+
+        private_key = data.get("private_key")
+        if private_key is None:
+            log.info("Initialize private key.")
+            private_key = generate_private_key(password=None)
+            data["private_key"] = private_key.decode()
+        return private_key
+
+    def install(self, event) -> None:
+        """Regenerate the private key on the leader unit on install."""
+        self._regenerate_private_key(self._get_replica_data(event, writable=True))
+
+    def _on_available(self, event: CertificateAvailableEvent):
+        if replica_data := self._get_replica_data(event, writable=True):
+            replica_data.update(
+                {
+                    "certificate": event.certificate,
+                    "ca": event.ca,
+                    "chain": "\n\n".join(event.chain),
+                }
+            )
+
+    @staticmethod
+    def _csr_attrs(csr: bytes):
+        csr_object = x509.load_pem_x509_csr(csr)
+        sans = csr_object.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        names = sans.value.get_values_for_type(x509.DNSName)
+        ips = sans.value.get_values_for_type(x509.IPAddress)
+        return csr_object.subject, names, ips
+
+    def _on_expiring(self, event):
+        if replica_data := self._get_replica_data(event, writable=True):
+            log.info("Current certificate expired, requesting a new one.")
+            private_key = replica_data.get("private_key")
+            old_csr = replica_data.get("csr")
+            subject, names, ips = self._csr_attrs(old_csr)
+
+            new_csr = generate_csr(
+                private_key=private_key.encode(),
+                private_key_password=None,
+                subject=subject,
+                sans_dns=names,
+                sans_ip=ips,
+            )
+            self._telco_relation.request_certificate_renewal(
+                old_certificate_signing_request=old_csr,
+                new_certificate_signing_request=new_csr,
+            )
+            replica_data.update({"csr": new_csr.decode()})
+
+    def _revoke(self, event):
+        if replica_data := self._get_replica_data(event, writable=True):
+            log.info("Current certificate revoked, requesting a new one.")
+            private_key = replica_data.get("private_key")
+            old_csr = replica_data.get("csr").encode()
+            subject, names, ips = self._csr_attrs(old_csr)
+
+            new_csr = generate_csr(
+                private_key=private_key.encode(),
+                private_key_password=None,
+                subject=subject,
+                sans_dns=names,
+                sans_ip=ips,
+            )
+            self._telco_relation.request_certificate_renewal(
+                old_certificate_signing_request=old_csr,
+                new_certificate_signing_request=new_csr,
+            )
+            replica_data.update({"csr": new_csr.decode()})
+            replica_data.pop("certificate")
+            replica_data.pop("ca")
+
+    def _on_invalidated(self, event) -> None:
+        if event.reason == "revoked":
+            self._revoke(event)
+        if event.reason == "expired":
+            self._on_expiring(event)
 
     @property
     def relation(self):
         """Yields the model view of the connected relation."""
         return self._legacy_relation.relation
 
-    def certificate(self, common_name: str) -> Optional[Certificate]:
+    def certificate(self) -> Optional[Certificate]:
         """Cert is available when it appears in the certs map."""
-        cert_databag = self._legacy_relation.server_certs_map.get(common_name)
-        if cert_databag:
+        if self._legacy_relation.is_ready:
+            cert_databag = self._legacy_relation.server_certs_map
+            if cert_databag:
+                log.info("Using Certificate from legacy tls-certificates relation.")
+                cert_response, *_ = cert_databag.values()
+                return Certificate(
+                    cert_response.common_name,
+                    cert_response.cert.encode(),
+                    cert_response.key.encode(),
+                    self._legacy_relation.ca.encode(),
+                )
+            else:
+                log.warning("Waiting on Certificate from legacy tls-certificates relation.")
+                return None
+
+        if not (replica_data := self._get_replica_data(None)):
+            log.warning("Replica data not yet populated.")
+            return None
+
+        csr = replica_data.get("csr")
+        if not csr:
+            log.warning("Have yet to request telco tls-certificate.")
+            return None
+
+        subject, *_ = self._csr_attrs(csr.encode())
+
+        if all(replica_data.get(key) for key in ["certificate", "ca"]):
+            log.info("Using Certificate from telco tls-certificates relation.")
+            cert = replica_data["certificate"] + "\n" + replica_data["chain"]
             return Certificate(
-                common_name,
-                cert_databag.cert.encode(),
-                cert_databag.key.encode(),
-                self._legacy_relation.ca.encode(),
+                subject,
+                cert.encode(),
+                replica_data["private_key"].encode(),
+                replica_data["ca"].encode(),
             )
+        else:
+            log.warning("Waiting on Certificate from telco tls-certificates relation.")
+            return None

--- a/src/relation_cert.py
+++ b/src/relation_cert.py
@@ -1,0 +1,39 @@
+"""Various ways for the admission webhook service to request a TLS cert package."""
+
+from typing import List
+
+from ops.interface_tls_certificates.requires import CertificatesRequires
+
+
+class RelationCert:
+    """Request certificate package via the tls-interface relation."""
+
+    def __init__(self, relation: CertificatesRequires, common_name: str):
+        self._relation = relation
+        self._common_name = common_name
+
+    def request(self, sans: List[str]):
+        """Generate certs based on the common_name and sans."""
+        self._relation.request_server_cert(self._common_name, sans)
+
+    @property
+    def available(self):
+        """Cert is available when it appears in the certs map."""
+        return self._common_name in self._relation.server_certs_map
+
+    @property
+    def cert(self) -> bytes:
+        """Representation of a tls certificate."""
+        certificate = self._relation.server_certs_map[self._common_name]
+        return certificate.cert.encode()
+
+    @property
+    def key(self) -> bytes:
+        """Representation of a private key file."""
+        certificate = self._relation.server_certs_map[self._common_name]
+        return certificate.key.encode()
+
+    @property
+    def ca(self) -> bytes:
+        """Representation of a ca cert."""
+        return self._relation.ca.encode()

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -1,0 +1,19 @@
+description: Overlay for testing current charm
+bundle: kubernetes
+applications:
+  tls-certificates:
+    charm: tls-certificates-operator
+    scale: 1
+    config:
+      ca-common-name: {{model_name}}
+      generate-self-signed-certificates: true
+  dashboard:
+    charm: {{charm}}
+    resources: {{resources}}
+    trust: true
+    series: {{series}}
+    constraints: arch={{arch}}
+    scale: 1
+relations:
+- - dashboard:certificates
+  - tls-certificates:certificates

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -4,7 +4,7 @@ applications:
   tls-certificates:
     charm: tls-certificates-operator
     scale: 1
-    config:
+    options:
       ca-common-name: {{model_name}}
       generate-self-signed-certificates: true
   dashboard:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--arch", action="store", default="amd64")
-    parser.addoption("--series", action="store", default="focal")
+    parser.addoption("--series", action="store", default="jammy")
 
 
 @pytest.fixture
@@ -14,5 +14,3 @@ def arch(request):
 @pytest.fixture
 def series(request):
     return request.config.getoption("--series")
-
-

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,3 +14,5 @@ def arch(request):
 @pytest.fixture
 def series(request):
     return request.config.getoption("--series")
+
+

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@
 
 
 import logging
+import shlex
 import ssl
 import urllib.request
 from pathlib import Path
@@ -22,6 +23,7 @@ from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
+
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 
 
@@ -32,23 +34,34 @@ async def test_build_and_deploy(ops_test: OpsTest, arch: str, series: str):
     Assert on the unit status before any relations/configurations take place.
     """
     # build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
-    resources = {
-        "dashboard-image": METADATA["resources"]["dashboard-image"]["upstream-source"],
-        "scraper-image": METADATA["resources"]["scraper-image"]["upstream-source"],
+    charm = next(Path(".").glob("kubernetes-dashboard*.charm"), None)
+    if not charm:
+        logger.info("Build Charm...")
+        charm = await ops_test.build_charm(".")
+
+    bundles = [Path("tests/data/charm.yaml")]
+    context = {
+        "arch": arch,
+        "charm": charm.resolve(),
+        "model_name": ops_test.model_name,
+        "resources": {
+            "dashboard-image": METADATA["resources"]["dashboard-image"]["upstream-source"],
+            "scraper-image": METADATA["resources"]["scraper-image"]["upstream-source"],
+        },
+        "series": series,
     }
-    await ops_test.model.deploy(
-        charm,
-        resources=resources,
-        application_name="dashboard",
-        trust=True,
-        series=series,
-        constraints=f"arch={arch}",
-    )
+    bundle, = await ops_test.async_render_bundles(*bundles, **context)
+
+    logger.info("Deploy Charm...")
+    model = ops_test.model_full_name
+    cmd = f"juju deploy -m {model} {bundle} --trust"
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
+    logger.info(stdout)
 
     # issuing dummy update_status just to trigger an event
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=["dashboard"], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(apps=["dashboard"], status="active", timeout=60*5)
         assert ops_test.model.applications["dashboard"].units[0].workload_status == "active"
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,6 @@
 
 
 import unittest
-from contextlib import contextmanager
 from glob import glob
 from ipaddress import IPv4Address
 from types import SimpleNamespace
@@ -26,7 +25,7 @@ from lightkube.models.core_v1 import (
     VolumeMount,
 )
 from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus, ErrorStatus
+from ops.model import ActiveStatus, BlockedStatus, ErrorStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import APIError, ChangeError, ConnectionError
 from ops.testing import Harness
 
@@ -81,7 +80,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect("dashboard", True)
         self.harness.set_can_connect("scraper", True)
         self.charm = self.harness.charm
-        
+
     def _dashboard_service(self, *, started=False) -> None:
         container = self.charm.unit.get_container("dashboard")
         layer = {"services": {"dashboard": {}}}
@@ -124,7 +123,7 @@ class TestCharm(unittest.TestCase):
     def test_dashboard_interface_tls_ready_no_dashboard(self, status, configure_tls_certs):
         # self._dashboard_service() -- no dashboard service
         with patch.object(self.harness.charm, "interface_tls") as mock_tls_interface:
-            mock_tls_interface.evaluate_relation.return_value = None 
+            mock_tls_interface.evaluate_relation.return_value = None
             self.harness.add_relation("certificates", "easyrsa")
         # Check the method returned without trying to configure the dashboard
         configure_tls_certs.assert_not_called()
@@ -135,7 +134,7 @@ class TestCharm(unittest.TestCase):
         self._dashboard_service()
         configure_tls_certs.return_value = False
         with patch.object(self.harness.charm, "interface_tls") as mock_tls_interface:
-            mock_tls_interface.evaluate_relation.return_value = None 
+            mock_tls_interface.evaluate_relation.return_value = None
             self.harness.add_relation("certificates", "easyrsa")
         # Check the method returned without trying to configure the dashboard
         configure_tls_certs.assert_called_once_with(False)
@@ -336,13 +335,15 @@ class TestCharm(unittest.TestCase):
             self.charm.interface_tls,
             common_name="kubernetes-dashboard.dashboard",
         )
-        cert.return_value.request.assert_called_once_with(sans=[
-            "kubernetes-dashboard.dashboard",
-            "kubernetes-dashboard.dashboard.svc",
-            "kubernetes-dashboard.dashboard.svc.cluster.local",
-            "10.10.10.10", 
-            "1.1.1.1"
-        ])
+        cert.return_value.request.assert_called_once_with(
+            sans=[
+                "kubernetes-dashboard.dashboard",
+                "kubernetes-dashboard.dashboard.svc",
+                "kubernetes-dashboard.dashboard.svc.cluster.local",
+                "10.10.10.10",
+                "1.1.1.1",
+            ]
+        )
         container = self.charm.unit.get_container("dashboard")
         assert not any(container.list_files("/certs"))
 
@@ -559,6 +560,7 @@ class TestCharm(unittest.TestCase):
         self.charm.unit.status = ErrorStatus()
         self.charm._evaluate_dashboard_status()
         assert self.charm.unit.status == ActiveStatus()
+
 
 class TestCharmNamespaceProperty(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="dashboard")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -277,7 +277,7 @@ class TestCharm(unittest.TestCase):
                 "kubernetes-dashboard.dashboard.svc",
                 "kubernetes-dashboard.dashboard.svc.cluster.local",
             ],
-            ips=[IPv4Address("10.10.10.10"), IPv4Address("1.1.1.1")],
+            ips=[IPv4Address("1.1.1.1"), IPv4Address("10.10.10.10")],
         )
         container = self.charm.unit.get_container("dashboard")
         self.assertEqual(container.pull("/certs/tls.crt").read(), "deadbeef")
@@ -296,7 +296,7 @@ class TestCharm(unittest.TestCase):
                 "kubernetes-dashboard.dashboard.svc",
                 "kubernetes-dashboard.dashboard.svc.cluster.local",
             ],
-            ips=[IPv4Address("10.10.10.10"), IPv4Address("1.1.1.1")],
+            ips=[IPv4Address("1.1.1.1"), IPv4Address("10.10.10.10")],
         )
         container = self.charm.unit.get_container("dashboard")
         self.assertEqual(container.pull("/certs/tls.crt").read(), "deadbeef")
@@ -309,7 +309,7 @@ class TestCharm(unittest.TestCase):
         get.return_value = Service(spec=ServiceSpec(clusterIP="1.1.1.1"))
         assert self.charm._configure_tls_certs(False)
         get.assert_called_once()
-        cert.assert_called_once_with("kubernetes-dashboard.dashboard")
+        cert.assert_called_once_with()
         container = self.charm.unit.get_container("dashboard")
         self.assertEqual(container.pull("/certs/tls.crt").read(), "deadbeef")
         self.assertEqual(container.pull("/certs/tls.key").read(), "deadbeef")
@@ -322,16 +322,16 @@ class TestCharm(unittest.TestCase):
         get.return_value = Service(spec=ServiceSpec(clusterIP="1.1.1.1"))
         assert not self.charm._configure_tls_certs(False)
         get.assert_called_once()
-        common_name = "kubernetes-dashboard.dashboard"
-        cert.assert_called_once_with(common_name)
+        cert.assert_called_once_with()
         request.assert_called_once_with(
-            common_name,
-            sans=[
+            names=[
                 "kubernetes-dashboard.dashboard",
                 "kubernetes-dashboard.dashboard.svc",
                 "kubernetes-dashboard.dashboard.svc.cluster.local",
-                "10.10.10.10",
-                "1.1.1.1",
+            ],
+            ips=[
+                IPv4Address("1.1.1.1"),
+                IPv4Address("10.10.10.10"),
             ],
         )
         container = self.charm.unit.get_container("dashboard")

--- a/tests/unit/test_relation_cert.py
+++ b/tests/unit/test_relation_cert.py
@@ -1,0 +1,50 @@
+import unittest
+import unittest.mock as mock
+
+from ops.interface_tls_certificates import CertificatesRequires
+from ops.interface_tls_certificates.model import Certificate
+from relation_cert import RelationCert
+
+class TestRelationCert(unittest.TestCase):
+    def setUp(self) -> None:
+        self._name = "testCN"
+        self.relation = mock.MagicMock(autospec=CertificatesRequires)
+        self.relation.ca = "ca-cert-data"
+
+    def with_cert(self, rel_cert: RelationCert):
+        cert = Certificate(
+            cert_type="server",
+            common_name=self._name,
+            cert="public-data",
+            key="private-data"
+        )
+        rel_cert._relation.server_certs_map = {self._name: cert}
+
+    def test_request(self):
+        rel_cert = RelationCert(self.relation, self._name)
+        rel_cert.request(["abc"])
+        self.relation.request_server_cert.assert_called_once_with(self._name, ["abc"])
+    
+    def test_is_available(self):
+        rel_cert = RelationCert(self.relation, self._name)
+        self.with_cert(rel_cert)
+        assert rel_cert.available
+    
+    def test_is_not_available(self):
+        rel_cert = RelationCert(self.relation, self._name)
+        self.relation.server_certs_map = {}
+        assert not rel_cert.available
+
+    def test_cert_value(self):
+        rel_cert = RelationCert(self.relation, self._name)
+        self.with_cert(rel_cert)
+        assert rel_cert.cert == b"public-data"
+
+    def test_key_value(self):
+        rel_cert = RelationCert(self.relation, self._name)
+        self.with_cert(rel_cert)
+        assert rel_cert.key == b"private-data"
+
+    def test_ca(self):
+        rel_cert = RelationCert(self.relation, self._name)
+        assert rel_cert.ca == b"ca-cert-data"

--- a/tests/unit/test_relation_cert.py
+++ b/tests/unit/test_relation_cert.py
@@ -1,4 +1,6 @@
 import unittest
+from functools import lru_cache
+from ipaddress import IPv4Address
 
 from ops.interface_tls_certificates import CertificatesRequires
 from ops.interface_tls_certificates.model import Certificate
@@ -7,34 +9,101 @@ from relation_cert import CertificatesRelation
 
 class TestRelationCert(unittest.TestCase):
     def setUp(self) -> None:
-        self.common_name = "testCN"
         self.charm = unittest.mock.MagicMock()
-        with unittest.mock.patch(
-            "relation_cert.CertificatesRequires", autospec=CertificatesRequires
-        ) as r:
-            self.legacy_relation = r.return_value
-            self.legacy_relation.ca = "ca-cert-data"
-            self.legacy_relation.server_certs_map = {}
-            self.interface_tls = CertificatesRelation(self.charm)
+        self.fqdn = ["testCN", "abc"]
+        self.ips = [IPv4Address("1.2.3.4")]
+        mock_telco = (
+            "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2"
+        )
+        mock_legacy = "relation_cert.CertificatesRequires"
+        with unittest.mock.patch(mock_telco) as telco:
+            with unittest.mock.patch(mock_legacy, autospec=CertificatesRequires) as legacy:
+                self.telco_relation = telco.return_value
+                self.legacy_relation = legacy.return_value
+                self.legacy_relation.ca = "ca-cert-data"
+                self.legacy_relation.server_certs_map = {}
+                self.interface_tls = CertificatesRelation(self.charm)
 
-    def test_is_available(self):
+        @lru_cache
+        def relation_mapper(relation_name):
+            relation = unittest.mock.MagicMock()
+            relation.data = {
+                self.charm.app: {},
+                self.interface_tls.model.unit: {},
+            }
+
+            return relation
+
+        self.interface_tls.model.get_relation.side_effect = relation_mapper
+
+    def test_install(self):
+        replicas = self.interface_tls.model.get_relation("replicas")
+        replicas_data = replicas.data[self.charm.app]
+        install_event = unittest.mock.MagicMock()
+        self.interface_tls.install(install_event)
+        assert isinstance(replicas_data["private_key"], str)
+
+    def test_legacy_available(self):
+        subject = self.fqdn[0]
         cert = Certificate(
             cert_type="server",
-            common_name=self.common_name,
+            common_name=subject,
             cert="public-data",
             key="private-data",
         )
-        self.legacy_relation.server_certs_map = {self.common_name: cert}
-        cert = self.interface_tls.certificate(self.common_name)
+        self.legacy_relation.server_certs_map = {subject: cert}
+        self.legacy_relation.is_ready = True
+        cert = self.interface_tls.certificate()
         assert cert
         assert cert.cert == b"public-data"
         assert cert.key == b"private-data"
         assert cert.ca == b"ca-cert-data"
 
-    def test_is_not_available(self):
+    def test_legacy_not_available(self):
+        self.legacy_relation.is_ready = True
         self.legacy_relation.server_certs_map = {}
-        assert not self.interface_tls.certificate(self.common_name)
+        assert self.interface_tls.certificate() is None
+
+    def test_telco_relation(self):
+        self.legacy_relation.is_ready = False
+        assert not self.interface_tls.certificate()
+
+        install_event = unittest.mock.MagicMock()
+        self.interface_tls.install(install_event)
+        assert not self.interface_tls.certificate()
+
+        replicas = self.interface_tls.model.get_relation("replicas")
+        replicas_data = replicas.data[self.charm.app]
+        replicas_data["csr"] = unittest.mock.MagicMock()
+        self.interface_tls._csr_attrs = unittest.mock.MagicMock(
+            return_value=(self.fqdn[0], self.fqdn, self.ips)
+        )
+
+        assert not self.interface_tls.certificate()
+        available_event = unittest.mock.MagicMock()
+        available_event.certificate = "123"
+        available_event.chain = ["abc", "def"]
+
+        self.interface_tls._on_available(available_event)
+        cert = self.interface_tls.certificate()
+        assert cert.common_name == self.fqdn[0]
+        assert cert.cert == b"123\nabc\n\ndef"
+        assert cert.key == replicas_data["private_key"].encode()
+        assert cert.ca == available_event.ca.encode.return_value
 
     def test_request(self):
-        self.interface_tls.request(self.common_name, ["abc"])
-        self.legacy_relation.request_server_cert.assert_called_once_with(self.common_name, ["abc"])
+        subject = self.fqdn[0]
+        install_event = unittest.mock.MagicMock()
+        self.interface_tls.install(install_event)
+
+        self.interface_tls.request(self.fqdn, self.ips)
+        expected_sans = self.fqdn + [str(_) for _ in self.ips]
+        self.legacy_relation.request_server_cert.assert_called_once_with(subject, expected_sans)
+
+        replicas = self.interface_tls.model.get_relation("replicas")
+        certificates = self.interface_tls.model.get_relation("certificates")
+
+        replicas_data = replicas.data[self.charm.app]
+        certificate_data = certificates.data[self.interface_tls.model.unit]
+        assert isinstance(replicas_data["csr"], str)
+        assert isinstance(certificate_data["certificate_signing_requests"], str)

--- a/tests/unit/test_relation_cert.py
+++ b/tests/unit/test_relation_cert.py
@@ -1,109 +1,266 @@
 import unittest
-from functools import lru_cache
+import unittest.mock as mock
 from ipaddress import IPv4Address
 
-from ops.interface_tls_certificates import CertificatesRequires
-from ops.interface_tls_certificates.model import Certificate
-from relation_cert import CertificatesRelation
+from ops.interface_tls_certificates.model import Certificate as OpsCert
+from relation_cert import CertificatesRelation, LegacyRequires, TelcoRequires
 
 
 class TestRelationCert(unittest.TestCase):
     def setUp(self) -> None:
         self.charm = unittest.mock.MagicMock()
-        self.fqdn = ["testCN", "abc"]
-        self.ips = [IPv4Address("1.2.3.4")]
-        mock_telco = (
-            "charms.tls_certificates_interface.v2.tls_certificates.TLSCertificatesRequiresV2"
-        )
-        mock_legacy = "relation_cert.CertificatesRequires"
-        with unittest.mock.patch(mock_telco) as telco:
-            with unittest.mock.patch(mock_legacy, autospec=CertificatesRequires) as legacy:
-                self.telco_relation = telco.return_value
-                self.legacy_relation = legacy.return_value
-                self.legacy_relation.ca = "ca-cert-data"
-                self.legacy_relation.server_certs_map = {}
+        mock_telco = "relation_cert.TelcoRequires"
+        mock_legacy = "relation_cert.LegacyRequires"
+
+        with mock.patch(mock_telco, autospec=TelcoRequires):
+            with mock.patch(mock_legacy, autospec=LegacyRequires):
                 self.interface_tls = CertificatesRelation(self.charm)
 
-        @lru_cache
-        def relation_mapper(relation_name):
-            relation = unittest.mock.MagicMock()
-            relation.data = {
-                self.charm.app: {},
-                self.interface_tls.model.unit: {},
-            }
-
-            return relation
-
-        self.interface_tls.model.get_relation.side_effect = relation_mapper
+    def test_relation(self):
+        rel1 = self.interface_tls.relation
+        rel2 = self.interface_tls.relation
+        assert rel1 is rel2
+        self.interface_tls.model.get_relation.assert_called_once_with("certificates")
 
     def test_install(self):
-        replicas = self.interface_tls.model.get_relation("replicas")
-        replicas_data = replicas.data[self.charm.app]
-        install_event = unittest.mock.MagicMock()
-        self.interface_tls.install(install_event)
-        assert isinstance(replicas_data["private_key"], str)
+        event = mock.MagicMock()
+        self.interface_tls.install(event)
+        self.interface_tls._telco_relation.install.assert_called_once_with(event)
 
-    def test_legacy_available(self):
-        subject = self.fqdn[0]
-        cert = Certificate(
+    def test_certificate_by_legacy(self):
+        cert = self.interface_tls.certificate()
+        self.interface_tls._legacy_relation.get_certificate.assert_called_once_with()
+        assert cert == self.interface_tls._legacy_relation.get_certificate.return_value
+        self.interface_tls._telco_relation.get_certificate.assert_not_called()
+
+    def test_certificate_by_telco(self):
+        self.interface_tls._legacy_relation.get_certificate.return_value = None
+        cert = self.interface_tls.certificate()
+        self.interface_tls._legacy_relation.get_certificate.assert_called_once_with()
+        self.interface_tls._telco_relation.get_certificate.assert_called_once_with()
+        assert cert == self.interface_tls._telco_relation.get_certificate.return_value
+
+    def test_request(self):
+        names, ips = unittest.mock.MagicMock(), unittest.mock.MagicMock()
+        self.interface_tls.request(names, ips)
+        self.interface_tls._legacy_relation.request.assert_called_once_with(names, ips)
+        self.interface_tls._telco_relation.request.assert_called_once_with(names, ips)
+
+
+class TestLegacyRequires(unittest.TestCase):
+    def setUp(self) -> None:
+        self.charm = unittest.mock.MagicMock()
+        self.legacy = LegacyRequires(self.charm, "certificates")
+
+    @mock.patch("relation_cert.CertificatesRequires.is_ready", new_callable=mock.PropertyMock)
+    def test_certificate_not_ready(self, mock_is_ready):
+        mock_is_ready.return_value = False
+        cert = self.legacy.get_certificate()
+        mock_is_ready.assert_called_once_with()
+        assert cert is None
+
+    @mock.patch("relation_cert.CertificatesRequires.is_ready", new_callable=mock.PropertyMock)
+    @mock.patch(
+        "relation_cert.CertificatesRequires.server_certs_map", new_callable=mock.PropertyMock
+    )
+    def test_certificate_ready_no_certs_yet(self, mock_certs_map, mock_is_ready):
+        mock_certs_map.return_value = {}
+        cert = self.legacy.get_certificate()
+        mock_is_ready.assert_called_once()
+        mock_certs_map.assert_called_once()
+        assert cert is None
+
+    @mock.patch("relation_cert.CertificatesRequires.is_ready", new_callable=mock.PropertyMock)
+    @mock.patch(
+        "relation_cert.CertificatesRequires.server_certs_map", new_callable=mock.PropertyMock
+    )
+    @mock.patch("relation_cert.CertificatesRequires.ca", new_callable=mock.PropertyMock)
+    def test_certificate_ready(self, mock_ca, mock_certs_map, mock_is_ready):
+        subject = "testCN"
+        cert = OpsCert(
             cert_type="server",
             common_name=subject,
             cert="public-data",
             key="private-data",
         )
-        self.legacy_relation.server_certs_map = {subject: cert}
-        self.legacy_relation.is_ready = True
-        cert = self.interface_tls.certificate()
-        assert cert
+        mock_certs_map.return_value = {subject: cert}
+        cert = self.legacy.get_certificate()
+        mock_is_ready.assert_called_once()
+        mock_certs_map.assert_called_once()
+        mock_ca.assert_called_once()
+        assert cert.common_name == subject
         assert cert.cert == b"public-data"
         assert cert.key == b"private-data"
-        assert cert.ca == b"ca-cert-data"
+        assert cert.ca == mock_ca().encode.return_value
 
-    def test_legacy_not_available(self):
-        self.legacy_relation.is_ready = True
-        self.legacy_relation.server_certs_map = {}
-        assert self.interface_tls.certificate() is None
+    @mock.patch("relation_cert.CertificatesRequires.request_server_cert")
+    def test_request(self, mock_request):
+        names, ips = ["testCN", "abc"], [IPv4Address("1.2.3.4")]
+        self.legacy.request(names, ips)
+        mock_request.assert_called_once_with(names[0], names + ["1.2.3.4"])
 
-    def test_telco_relation(self):
-        self.legacy_relation.is_ready = False
-        assert not self.interface_tls.certificate()
 
-        install_event = unittest.mock.MagicMock()
-        self.interface_tls.install(install_event)
-        assert not self.interface_tls.certificate()
+class TestTelcoRequires(unittest.TestCase):
+    def setUp(self) -> None:
+        self.charm = unittest.mock.MagicMock()
+        self.telco = TelcoRequires(self.charm, "certificates")
 
-        replicas = self.interface_tls.model.get_relation("replicas")
-        replicas_data = replicas.data[self.charm.app]
-        replicas_data["csr"] = unittest.mock.MagicMock()
-        self.interface_tls._csr_attrs = unittest.mock.MagicMock(
-            return_value=(self.fqdn[0], self.fqdn, self.ips)
+    def test_get_replica_data(self):
+        event = mock.MagicMock()
+
+        relation = self.telco.model.get_relation()
+        relation_app_content = {"valid": "relation-content"}
+        relation.data = {self.charm.app: relation_app_content}
+        assert self.telco._get_replica_data(event, writable=True) == relation_app_content
+        event.defer.assert_not_called()
+
+        self.telco.model.unit.is_leader.return_value = False
+        assert self.telco._get_replica_data(event, writable=True) is None
+        event.defer.assert_not_called()
+
+        self.telco.model.get_relation.return_value = None
+        assert self.telco._get_replica_data(event, writable=True) is None
+        event.defer.assert_called_once()
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    @mock.patch("relation_cert.generate_private_key")
+    def test_install_no_replica_yet(self, mock_generate_private_key, mock_replica_data):
+        mock_replica_data.return_value = None
+        event = mock.MagicMock()
+        self.telco.install(event)
+        mock_replica_data.assert_called_once_with(event, writable=True)
+        mock_generate_private_key.assert_not_called()
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    @mock.patch("relation_cert.generate_private_key")
+    def test_install_with_replicas(self, mock_generate_private_key, mock_replica_data):
+        mock_replica_data.return_value = {"private_key": "something"}
+        event = mock.MagicMock()
+        self.telco.install(event)
+        mock_replica_data.assert_called_once_with(event, writable=True)
+        mock_generate_private_key.assert_not_called()
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    @mock.patch("relation_cert.generate_private_key")
+    def test_install_empty_replicas(self, mock_generate_private_key, mock_replica_data):
+        data = mock_replica_data.return_value = {}
+        event = mock.MagicMock()
+        self.telco.install(event)
+        mock_replica_data.assert_called_once_with(event, writable=True)
+        mock_generate_private_key.assert_called_once_with(password=None)
+        assert data["private_key"] == mock_generate_private_key.return_value.decode()
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    def test_certificate_not_ready(self, mock_replica_data):
+        mock_replica_data.return_value = {}
+        cert = self.telco.get_certificate()
+        mock_replica_data.assert_called_once_with(None)
+        assert cert is None
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    def test_certificate_not_ready_no_csr(self, mock_replica_data):
+        mock_replica_data.return_value = {"private_key": "something"}
+        cert = self.telco.get_certificate()
+        mock_replica_data.assert_called_once_with(None)
+        assert cert is None
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    @mock.patch("relation_cert.TelcoRequires._csr_attrs")
+    def test_certificate_not_ready_no_ca(self, mock_csr_attrs, mock_replica_data):
+        mock_replica_data.return_value = {
+            "private_key": "private-data",
+            "csr": "--certificate-signing-request--",
+        }
+        names, ips = ["testCN", "abc"], [IPv4Address("1.2.3.4")]
+        mock_csr_attrs.return_value = (names[0], names, ips)
+
+        cert = self.telco.get_certificate()
+
+        mock_replica_data.assert_called_once_with(None)
+        mock_csr_attrs.assert_called_once_with(b"--certificate-signing-request--")
+        assert cert is None
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    @mock.patch("relation_cert.TelcoRequires._csr_attrs")
+    def test_certificate_ready(self, mock_csr_attrs, mock_replica_data):
+        mock_replica_data.return_value = {
+            "private_key": "private-data",
+            "csr": "--certificate-signing-request--",
+            "certificate": "public-data",
+            "ca": "ca-data",
+            "chain": "chain1\n\nchain2",
+        }
+        names, ips = ["testCN", "abc"], [IPv4Address("1.2.3.4")]
+        mock_csr_attrs.return_value = (names[0], names, ips)
+
+        cert = self.telco.get_certificate()
+
+        mock_replica_data.assert_called_once_with(None)
+        mock_csr_attrs.assert_called_once_with(b"--certificate-signing-request--")
+        assert cert.common_name == "testCN"
+        assert cert.cert == b"public-data\nchain1\n\nchain2"
+        assert cert.key == b"private-data"
+        assert cert.ca == b"ca-data"
+
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    @mock.patch("relation_cert.TLSCertificatesRequiresV2.request_certificate_creation")
+    @mock.patch("relation_cert.generate_csr")
+    def test_request(self, mock_generate_csr, mock_request, mock_replica_data):
+        names, ips = ["testCN", "abc"], [IPv4Address("1.2.3.4")]
+
+        mock_replica_data.return_value = None
+        self.telco.request(names, ips)
+        mock_generate_csr.assert_not_called()
+
+        data = mock_replica_data.return_value = {
+            "private_key": "private-data",
+        }
+        self.telco.request(names, ips)
+        mock_generate_csr.assert_called_once_with(
+            private_key=b"private-data",
+            private_key_password=None,
+            subject="testCN",
+            sans_dns=names,
+            sans_ip=ips,
         )
+        mock_request.assert_called_once_with(
+            certificate_signing_request=mock_generate_csr.return_value
+        )
+        assert data["csr"] == mock_generate_csr.return_value.decode()
 
-        assert not self.interface_tls.certificate()
-        available_event = unittest.mock.MagicMock()
-        available_event.certificate = "123"
-        available_event.chain = ["abc", "def"]
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    def test_csr_response(self, mock_replica_data):
+        data = mock_replica_data.return_value = {"csr": "--my-csr--"}
+        event = mock.MagicMock()
+        event.chain = ["chain1", "chain2"]
+        self.telco._on_available(event)
+        assert data == {
+            "certificate": event.certificate,
+            "ca": event.ca,
+            "chain": "chain1\n\nchain2",
+            "csr": "--my-csr--",
+        }
 
-        self.interface_tls._on_available(available_event)
-        cert = self.interface_tls.certificate()
-        assert cert.common_name == self.fqdn[0]
-        assert cert.cert == b"123\nabc\n\ndef"
-        assert cert.key == replicas_data["private_key"].encode()
-        assert cert.ca == available_event.ca.encode.return_value
-
-    def test_request(self):
-        subject = self.fqdn[0]
-        install_event = unittest.mock.MagicMock()
-        self.interface_tls.install(install_event)
-
-        self.interface_tls.request(self.fqdn, self.ips)
-        expected_sans = self.fqdn + [str(_) for _ in self.ips]
-        self.legacy_relation.request_server_cert.assert_called_once_with(subject, expected_sans)
-
-        replicas = self.interface_tls.model.get_relation("replicas")
-        certificates = self.interface_tls.model.get_relation("certificates")
-
-        replicas_data = replicas.data[self.charm.app]
-        certificate_data = certificates.data[self.interface_tls.model.unit]
-        assert isinstance(replicas_data["csr"], str)
-        assert isinstance(certificate_data["certificate_signing_requests"], str)
+    @mock.patch("relation_cert.TelcoRequires._get_replica_data")
+    @mock.patch("relation_cert.TLSCertificatesRequiresV2.request_certificate_renewal")
+    @mock.patch("relation_cert.generate_csr")
+    @mock.patch("relation_cert.TelcoRequires._csr_attrs")
+    def test_invalidate(self, mock_csr_attrs, mock_generate_csr, mock_request, mock_replica_data):
+        data = mock_replica_data.return_value = {
+            "private_key": "private-data",
+            "certificate": "--cert-data--",
+            "ca": "--ca-data--",
+            "chain": "chain1\n\nchain2",
+            "csr": "--my-csr--",
+        }
+        names, ips = ["testCN", "abc"], [IPv4Address("1.2.3.4")]
+        mock_csr_attrs.return_value = (names[0], names, ips)
+        new_csr = mock_generate_csr.return_value = b"--new-csr--"
+        event = mock.MagicMock()
+        event.reason = "revoked"
+        self.telco._on_invalidate(event)
+        mock_request.assert_called_once_with(
+            old_certificate_signing_request=b"--my-csr--",
+            new_certificate_signing_request=new_csr,
+        )
+        assert data == {"private_key": "private-data", "csr": "--new-csr--"}

--- a/tests/unit/test_relation_cert.py
+++ b/tests/unit/test_relation_cert.py
@@ -5,6 +5,7 @@ from ops.interface_tls_certificates import CertificatesRequires
 from ops.interface_tls_certificates.model import Certificate
 from relation_cert import RelationCert
 
+
 class TestRelationCert(unittest.TestCase):
     def setUp(self) -> None:
         self._name = "testCN"
@@ -13,10 +14,7 @@ class TestRelationCert(unittest.TestCase):
 
     def with_cert(self, rel_cert: RelationCert):
         cert = Certificate(
-            cert_type="server",
-            common_name=self._name,
-            cert="public-data",
-            key="private-data"
+            cert_type="server", common_name=self._name, cert="public-data", key="private-data"
         )
         rel_cert._relation.server_certs_map = {self._name: cert}
 
@@ -24,12 +22,12 @@ class TestRelationCert(unittest.TestCase):
         rel_cert = RelationCert(self.relation, self._name)
         rel_cert.request(["abc"])
         self.relation.request_server_cert.assert_called_once_with(self._name, ["abc"])
-    
+
     def test_is_available(self):
         rel_cert = RelationCert(self.relation, self._name)
         self.with_cert(rel_cert)
         assert rel_cert.available
-    
+
     def test_is_not_available(self):
         rel_cert = RelationCert(self.relation, self._name)
         self.relation.server_certs_map = {}

--- a/tests/unit/test_relation_cert.py
+++ b/tests/unit/test_relation_cert.py
@@ -1,48 +1,40 @@
 import unittest
-import unittest.mock as mock
 
 from ops.interface_tls_certificates import CertificatesRequires
 from ops.interface_tls_certificates.model import Certificate
-from relation_cert import RelationCert
+from relation_cert import CertificatesRelation
 
 
 class TestRelationCert(unittest.TestCase):
     def setUp(self) -> None:
-        self._name = "testCN"
-        self.relation = mock.MagicMock(autospec=CertificatesRequires)
-        self.relation.ca = "ca-cert-data"
-
-    def with_cert(self, rel_cert: RelationCert):
-        cert = Certificate(
-            cert_type="server", common_name=self._name, cert="public-data", key="private-data"
-        )
-        rel_cert._relation.server_certs_map = {self._name: cert}
-
-    def test_request(self):
-        rel_cert = RelationCert(self.relation, self._name)
-        rel_cert.request(["abc"])
-        self.relation.request_server_cert.assert_called_once_with(self._name, ["abc"])
+        self.common_name = "testCN"
+        self.charm = unittest.mock.MagicMock()
+        with unittest.mock.patch(
+            "relation_cert.CertificatesRequires", autospec=CertificatesRequires
+        ) as r:
+            self.legacy_relation = r.return_value
+            self.legacy_relation.ca = "ca-cert-data"
+            self.legacy_relation.server_certs_map = {}
+            self.interface_tls = CertificatesRelation(self.charm)
 
     def test_is_available(self):
-        rel_cert = RelationCert(self.relation, self._name)
-        self.with_cert(rel_cert)
-        assert rel_cert.available
+        cert = Certificate(
+            cert_type="server",
+            common_name=self.common_name,
+            cert="public-data",
+            key="private-data",
+        )
+        self.legacy_relation.server_certs_map = {self.common_name: cert}
+        cert = self.interface_tls.certificate(self.common_name)
+        assert cert
+        assert cert.cert == b"public-data"
+        assert cert.key == b"private-data"
+        assert cert.ca == b"ca-cert-data"
 
     def test_is_not_available(self):
-        rel_cert = RelationCert(self.relation, self._name)
-        self.relation.server_certs_map = {}
-        assert not rel_cert.available
+        self.legacy_relation.server_certs_map = {}
+        assert not self.interface_tls.certificate(self.common_name)
 
-    def test_cert_value(self):
-        rel_cert = RelationCert(self.relation, self._name)
-        self.with_cert(rel_cert)
-        assert rel_cert.cert == b"public-data"
-
-    def test_key_value(self):
-        rel_cert = RelationCert(self.relation, self._name)
-        self.with_cert(rel_cert)
-        assert rel_cert.key == b"private-data"
-
-    def test_ca(self):
-        rel_cert = RelationCert(self.relation, self._name)
-        assert rel_cert.ca == b"ca-cert-data"
+    def test_request(self):
+        self.interface_tls.request(self.common_name, ["abc"])
+        self.legacy_relation.request_server_cert.assert_called_once_with(self.common_name, ["abc"])

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps =
     # renovate: datasource=pypi
     pytest==7.3.0
     # renovate: datasource=pypi
-    pytest-operator==0.26.0
+    pytest-operator==0.27.0
     # renovate: datasource=pypi
     tenacity==8.2.2
     # renovate: datasource=pypi


### PR DESCRIPTION
This PR adds HTTPS  TLS Configuration via relations to the tls-interface endpoint

There are multiple competing standards of this relation:
* legacy-tls-certificates which relates to charms like `vault` and `easyrsa` in machine models
* telco-tls-certificates which relates to the `tls-certificates-operator` in k8s models

Simultaneously, when one removes this relation, the charm defaults back to a `SelfSignedCert`

* inclusion of `ops.interface-tls-certificates` pypi  library
* includes of `tls_certificates_interface.v2.tls_certificates` charm library
* unit tests


The includes on the second library makes this charm a binary specific charm needing binary specific python libraries.  In order to support multiple arches, it will depend on the merge of
* https://github.com/charmed-kubernetes/jenkins/pull/1376
